### PR TITLE
Allow deserialization of null geometry

### DIFF
--- a/NetTopologySuite.IO.GeoJSON.Test/NullGeometryTest.cs
+++ b/NetTopologySuite.IO.GeoJSON.Test/NullGeometryTest.cs
@@ -1,0 +1,58 @@
+﻿using NetTopologySuite.Geometries;
+using NUnit.Framework;
+
+namespace NetTopologySuite.IO.GeoJSON.Test
+{
+    public class NullGeometryTest
+    {
+        [Test]
+        public void TestDeserializeJsonObjectWithNullGeometry()
+        {
+            const string json = @"
+                {
+                    ""id"": 1,
+                    ""geometry"": null,
+                    ""theme"": {
+                        ""id"": 1
+                    }
+                }
+            ";
+            var reader = new GeoJsonReader();
+            var example = reader.Read<Example>(json);
+            Assert.That(example.Geometry, Is.Null);
+            Assert.That(example.Theme, Is.Not.Null);
+            Assert.That(example.Theme.Id, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void TestDeserializeJsonObjectWithGeometry()
+        {
+            const string json = @"
+                {
+                    ""id"": 1,
+                    ""geometry"": {""type"":""Point"",""coordinates"":[23.0,56.0]},
+                    ""theme"": {
+                        ""id"": 1
+                    }
+                }
+            ";
+            var reader = new GeoJsonReader();
+            var example = reader.Read<Example>(json);
+            Assert.That(example.Geometry, Is.Not.Null);
+            Assert.That(example.Theme, Is.Not.Null);
+            Assert.That(example.Theme.Id, Is.EqualTo(1));
+        }
+    }
+
+    class Example
+    {
+        public int Id { get; set; }
+        public Geometry Geometry { get; set; }
+        public Theme Theme { get; set; }
+    }
+
+    class Theme
+    {
+        public int Id { get; set; }
+    }
+}

--- a/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
+++ b/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
@@ -238,6 +238,11 @@ namespace NetTopologySuite.IO.Converters
 
         private IGeometry ParseGeometry(JsonReader reader, JsonSerializer serializer)
         {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
             if (reader.TokenType != JsonToken.StartObject)
                 throw new JsonReaderException("Expected Start object '{' Token");
 


### PR DESCRIPTION
We wanted to use a GeoJson Geometry as a property in a json object, and have that deserialize to a NTS Geometry. This works, except when the property is null. This pull request resolves that problem. See the unit tests for an example usage.

This change works great for us, but I'm not sure if it might be unexpected behaviour in some other use case.