### PR TITLE
Add usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # GeoJSON
 GeoJSON IO module for NTS. 
+
+# Usage
+
+**GeoJSON to `Geometry`**:
+
+```c#
+var geoJson = "{\"type\":\"Point\",\"coordinates\":[0.0,0.0]}";
+Geometry geometry;
+
+var serializer = GeoJsonSerializer.Create();
+using (var stringReader = new StringReader(geoJson))
+using (var jsonReader = new JsonTextReader(stringReader))
+{
+    geometry = serializer.Deserialize<Geometry>(jsonReader);
+}
+```
+
+**`Geometry` to GeoJSON**:
+
+```c#
+var geometry = new Point(0, 0);
+string geoJson;
+
+var serializer = GeoJsonSerializer.Create();
+using (var stringWriter = new StringWriter())
+using (var jsonWriter = new JsonTextWriter(stringWriter))
+{
+    serializer.Serialize(jsonWriter, geometry);
+    geoJson = stringWriter.ToString();
+}
+```


### PR DESCRIPTION
This PR adds usage examples for converting between GeoJSON and `Geometry`.

At first I tried adding `[JsonConverter(typeof(GeometryConverter))]` to a property, but that doesn't seem to be a valid method to use the library because it results in an error similar to #4.
The examples are what I ended up using.