### PR TITLE
Don't use Serializer context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ NetTopologySuite.Samples.Shapefiles/tmp*.shx
 NetTopologySuite.Samples.Shapefiles/tmp*.dbf
 NetTopologySuite.Samples.Shapefiles/test_arcview.shp
 NetTopologySuite.Samples.Shapefiles/test_buffer.shp
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,9 @@ UpgradeLog*.htm
 # Microsoft Fakes
 FakesAssemblies/
 
+# JetBrains Rider
+.idea/
+
 # Data generated from unit tests
 NetTopologySuite.Samples.Shapefiles/ZMtest.shp
 NetTopologySuite.Samples.Shapefiles/ZMtest.shx
@@ -203,4 +206,3 @@ NetTopologySuite.Samples.Shapefiles/tmp*.shx
 NetTopologySuite.Samples.Shapefiles/tmp*.dbf
 NetTopologySuite.Samples.Shapefiles/test_arcview.shp
 NetTopologySuite.Samples.Shapefiles/test_buffer.shp
-.idea/

--- a/src/NetTopologySuite.IO.GeoJSON/Converters/AttributesTableConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/Converters/AttributesTableConverter.cs
@@ -148,20 +148,10 @@ namespace NetTopologySuite.IO.Converters
             // Advance reader
             reader.Read();
             reader.SkipComments();
-
-            IAttributesTable attributesTable = null;
-            if (!innerObject && serializer.Context.Context is IFeature feature)
-            {
-                attributesTable = feature.Attributes;
-            }
+            var attributesTable = new AttributesTable();
 
             if (reader.TokenType != JsonToken.Null)
             {
-                if (attributesTable is null)
-                {
-                    attributesTable = new AttributesTable();
-                }
-
                 while (reader.TokenType == JsonToken.PropertyName)
                 {
                     string attributeName = (string)reader.Value;

--- a/src/NetTopologySuite.IO.GeoJSON/Converters/FeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/Converters/FeatureConverter.cs
@@ -173,10 +173,23 @@ namespace NetTopologySuite.IO.Converters
                                 throw new ArgumentException("Expected token '{' not found.");
                             }
 
-                            var context = serializer.Context;
-                            serializer.Context = new StreamingContext(serializer.Context.State, feature);
-                            feature.Attributes = serializer.Deserialize<AttributesTable>(reader);
-                            serializer.Context = context;
+                            var attributes = serializer.Deserialize<AttributesTable>(reader);
+
+                            if (feature.Attributes is null)
+                            {
+                                feature.Attributes = attributes;
+                            }
+                            else
+                            {
+                                foreach (var attribute in attributes)
+                                {
+                                    if (!feature.Attributes.Exists(attribute.Key))
+                                    {
+                                        feature.Attributes.Add(attribute.Key, attribute.Value);
+                                    }
+                                }
+                            }
+
                             if (reader.TokenType != JsonToken.EndObject)
                             {
                                 throw new ArgumentException("Expected token '}' not found.");


### PR DESCRIPTION
Relates:elastic/elasticsearch-net#4791

This commit updates the AttributesTableConverter and FeatureConverter to not use the serializer context when deserializing AttributesTable. The serializer context is not safe to use multithreaded, which can be the case when JsonConverters from NetTopologySuite.IO.GeoJson are added to an singleton instance of JsonSerializer not under the control of NetTopologySuite.IO.GeoJson.