### PR TITLE
(Json.NET) Treat null arrays just like empty.

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
@@ -348,12 +348,28 @@ namespace NetTopologySuite.IO.Converters
                     case "geometries":
                         //only geom collection has "geometries"
                         reader.ReadOrThrow();  //read past start array tag
-                        coords = ParseGeomCollection(reader, serializer);
+                        if (reader.TokenType == JsonToken.Null)
+                        {
+                            reader.ReadOrThrow();
+                        }
+                        else
+                        {
+                            coords = ParseGeomCollection(reader, serializer);
+                        }
+
                         break;
 
                     case "coordinates":
                         reader.ReadOrThrow(); //read past start array tag
-                        coords = ReadCoordinates(reader);
+                        if (reader.TokenType == JsonToken.Null)
+                        {
+                            reader.ReadOrThrow();
+                        }
+                        else
+                        {
+                            coords = ReadCoordinates(reader);
+                        }
+
                         break;
 
                     case "bbox":
@@ -379,23 +395,44 @@ namespace NetTopologySuite.IO.Converters
 
             switch (geometryType)
             {
+                case GeoJsonObjectType.Point when coords is null:
+                    return _factory.CreatePoint();
+
                 case GeoJsonObjectType.Point:
                     return CreatePoint(reader, coords);
+
+                case GeoJsonObjectType.MultiPoint when coords is null:
+                    return _factory.CreateMultiPoint();
 
                 case GeoJsonObjectType.MultiPoint:
                     return _factory.CreateMultiPoint(coords.Select(obj => CreatePoint(reader, (List<object>)obj)).ToArray());
 
+                case GeoJsonObjectType.LineString when coords is null:
+                    return _factory.CreateLineString();
+
                 case GeoJsonObjectType.LineString:
                     return CreateLineString(reader, coords);
+
+                case GeoJsonObjectType.MultiLineString when coords is null:
+                    return _factory.CreateMultiLineString();
 
                 case GeoJsonObjectType.MultiLineString:
                     return _factory.CreateMultiLineString(coords.Select(obj => CreateLineString(reader, (List<object>)obj)).ToArray());
 
+                case GeoJsonObjectType.Polygon when coords is null:
+                    return _factory.CreatePolygon();
+
                 case GeoJsonObjectType.Polygon:
                     return CreatePolygon(reader, coords);
 
+                case GeoJsonObjectType.MultiPolygon when coords is null:
+                    return _factory.CreateMultiPolygon();
+
                 case GeoJsonObjectType.MultiPolygon:
                     return _factory.CreateMultiPolygon(coords.Select(obj => CreatePolygon(reader, (List<object>)obj)).ToArray());
+
+                case GeoJsonObjectType.GeometryCollection when coords is null:
+                    return _factory.CreateGeometryCollection();
 
                 case GeoJsonObjectType.GeometryCollection:
                     return _factory.CreateGeometryCollection(coords.Cast<Geometry>().ToArray());

--- a/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssues.cs
+++ b/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssues.cs
@@ -470,6 +470,25 @@ namespace NetTopologySuite.IO.GeoJSON.Test.Issues.NetTopologySuite.IO.GeoJSON
             Assert.That(innerTable["a"], Is.InstanceOf<List<object>>());
             Assert.That(innerTable["d"], Is.InstanceOf<List<object>>());
         }
+
+        [GeoJsonIssueNumber(65)]
+        [TestCase("Point")]
+        [TestCase("LineString")]
+        [TestCase("Polygon")]
+        [TestCase("MultiPoint")]
+        [TestCase("MultiLineString")]
+        [TestCase("MultiPolygon")]
+        [TestCase("GeometryCollection")]
+        public void TestGeoJsonWithNullCoordinatesOrGeometries(string geometryType)
+        {
+            string tag = geometryType == "GeometryCollection" ? "geometries" : "coordinates";
+            string geojson = $"{{\"type\": \"{geometryType}\", \"{tag}\": null}}";
+
+            Geometry g = null;
+            Assert.That(() => g = new GeoJsonReader().Read<Geometry>(geojson), Throws.Nothing);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g.IsEmpty);
+        }
     }
 
     class MyClass


### PR DESCRIPTION
Resolves #65

I can't find solid support that says definitively that we should be treating it this way.

However, it seems to make logical sense (null array meaning the same as empty array, which there **is** support for treating the way we do), and at least 4STJ 2.1.0 behaves this way right now, so we might as well interpret it as empty.

I think I'm going to submit a second PR to change 4STJ to write empty, though, for consistency with other implementations that I found.