### PR TITLE
(STJ) Write empty instead of null for "coordinates".

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -190,7 +190,8 @@ namespace NetTopologySuite.IO.Converters
             }
             else if (value.IsEmpty)
             {
-                writer.WriteNull("coordinates");
+                writer.WriteStartArray("coordinates");
+                writer.WriteEndArray();
             }
             else
             {


### PR DESCRIPTION
RFC 7946 doesn't say one way or the other what to do with null here, and I can't find support elsewhere for what we were doing.  It does, however, explicitly call out an empty array, and I do see other implementations using this, so we should prefer doing it this way.

Related to #65