### PR TITLE
Feature/skip unknown feature members

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -160,6 +160,8 @@ namespace NetTopologySuite.IO.Converters
                         break;
 
                     default:
+                        // If property name is not one of the above: skip it entirely
+                        reader.Skip();
                         // Advance
                         while (reader.Read())
                         {

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -160,7 +160,7 @@ namespace NetTopologySuite.IO.Converters
                         break;
 
                     default:
-                        // If property name is not one of the above: skip it entirely
+                        // If property name is not one of the above: skip it entirely (foreign member)
                         reader.Skip();
                         // Advance
                         while (reader.Read())

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureConverterTest.cs
@@ -43,7 +43,7 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
 
         [TestCase("{\"type\": \"Feature\", \"id\": 1, \"extra\": {\"example\": \"value\"}}")]
         [TestCase("{\"type\": \"Feature\", \"id\": 1, \"extra\": {\"type\": \"Line\", \"id\": 2}}")]
-        public void DeserializationShouldAllowExtraValues(string serializedFeature)
+        public void DeserializationShouldAllowForeignMembers(string serializedFeature)
         {
             Assert.That(() => JsonSerializer.Deserialize<IFeature>(serializedFeature, DefaultOptions), Throws.Nothing);
         }

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureConverterTest.cs
@@ -41,6 +41,13 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
             Assert.That(() => JsonSerializer.Deserialize<IFeature>(serializedFeature, DefaultOptions), Throws.Nothing);
         }
 
+        [TestCase("{\"type\": \"Feature\", \"id\": 1, \"extra\": {\"example\": \"value\"}}")]
+        [TestCase("{\"type\": \"Feature\", \"id\": 1, \"extra\": {\"type\": \"Line\", \"id\": 2}}")]
+        public void DeserializationShouldAllowExtraValues(string serializedFeature)
+        {
+            Assert.That(() => JsonSerializer.Deserialize<IFeature>(serializedFeature, DefaultOptions), Throws.Nothing);
+        }
+
         ///<summary>
         ///    A test for WriteJson
         ///</summary>


### PR DESCRIPTION
Hi maintainers,

According to https://tools.ietf.org/html/rfc7946#section-6.1 foreign members may be included in the GeoJSON input.

However, the parser did not cope well with foreign members which are objects themselves.

For example, parsing the following valid GeoJSON failed:

```
 {
   "type": "Feature",
   "id": "1",
   "geometry": {
     "type": "Point",
     "coordinates": [
       6.52,
       53.33
     ]
   },
   "properties": {
     "area": 61
   },
   "centroid": {
     "type": "Point",
     "coordinates": [
       6.52,
       53.33
     ]
   }
 }
```

Here, "centroid" is a foreign member.

This fix will ignore all foreign members when parsing and thus allow this kind of input. 