### PR TITLE
Custom coordinates formatting

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
@@ -73,24 +73,18 @@ namespace NetTopologySuite.IO.Converters
             _serializerSettingsForCoordinates = settingsForCoordinates;
         }
 
-        private JsonSerializerSettings BackupSerializerSettings(JsonSerializer serializer)
+        private JsonSerializerSettings BackupSerializerSettings(JsonWriter writer)
         {
             JsonSerializerSettings backupSettings = new JsonSerializerSettings
             {
-                Formatting = serializer.Formatting,
-                NullValueHandling = serializer.NullValueHandling,
-                ContractResolver = serializer.ContractResolver,
-                DefaultValueHandling = serializer.DefaultValueHandling
+                Formatting = writer.Formatting
             };
             return backupSettings;
         }
 
-        private void ApplySerializerSettings(JsonSerializer serializer, JsonSerializerSettings serializerSettings)
+        private void ApplySerializerSettings(JsonWriter writer, JsonSerializerSettings serializerSettings)
         {
-            serializer.Formatting = serializerSettings.Formatting;
-            serializer.NullValueHandling = serializerSettings.NullValueHandling;
-            serializer.ContractResolver = serializerSettings.ContractResolver;
-            serializer.DefaultValueHandling = serializerSettings.DefaultValueHandling;
+            writer.Formatting = serializerSettings.Formatting;
         }
 
         /// <summary>
@@ -120,16 +114,16 @@ namespace NetTopologySuite.IO.Converters
 
                     if (writeCoordinateData)
                     {
-                        var currentSerializerSettings = BackupSerializerSettings(serializer);
+                        var currentSerializerSettings = BackupSerializerSettings(writer);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, _serializerSettingsForCoordinates);
+                            ApplySerializerSettings(writer, _serializerSettingsForCoordinates);
                         }
                         writer.WritePropertyName("coordinates");
                         WriteCoordinates(writer, point.CoordinateSequence, false);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, currentSerializerSettings);
+                            ApplySerializerSettings(writer, currentSerializerSettings);
                         }
                     }
 
@@ -141,10 +135,10 @@ namespace NetTopologySuite.IO.Converters
 
                     if (writeCoordinateData)
                     {
-                        var currentSerializerSettings = BackupSerializerSettings(serializer);
+                        var currentSerializerSettings = BackupSerializerSettings(writer);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, _serializerSettingsForCoordinates);
+                            ApplySerializerSettings(writer, _serializerSettingsForCoordinates);
                         }
                         writer.WritePropertyName("coordinates");
                         writer.WriteStartArray();
@@ -153,7 +147,7 @@ namespace NetTopologySuite.IO.Converters
                         writer.WriteEndArray();
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, currentSerializerSettings);
+                            ApplySerializerSettings(writer, currentSerializerSettings);
                         }
                     }
 
@@ -165,16 +159,16 @@ namespace NetTopologySuite.IO.Converters
 
                     if (writeCoordinateData)
                     {
-                        var currentSerializerSettings = BackupSerializerSettings(serializer);
+                        var currentSerializerSettings = BackupSerializerSettings(writer);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, _serializerSettingsForCoordinates);
+                            ApplySerializerSettings(writer, _serializerSettingsForCoordinates);
                         }
                         writer.WritePropertyName("coordinates");
                         WriteCoordinates(writer, lineString.CoordinateSequence);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, currentSerializerSettings);
+                            ApplySerializerSettings(writer, currentSerializerSettings);
                         }
                     }
 
@@ -186,10 +180,10 @@ namespace NetTopologySuite.IO.Converters
 
                     if (writeCoordinateData)
                     {
-                        var currentSerializerSettings = BackupSerializerSettings(serializer);
+                        var currentSerializerSettings = BackupSerializerSettings(writer);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, _serializerSettingsForCoordinates);
+                            ApplySerializerSettings(writer, _serializerSettingsForCoordinates);
                         }
                         writer.WritePropertyName("coordinates");
                         writer.WriteStartArray();
@@ -198,7 +192,7 @@ namespace NetTopologySuite.IO.Converters
                         writer.WriteEndArray();
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, currentSerializerSettings);
+                            ApplySerializerSettings(writer, currentSerializerSettings);
                         }
                     }
 
@@ -209,16 +203,16 @@ namespace NetTopologySuite.IO.Converters
                     writer.WriteValue(nameof(GeoJsonObjectType.Polygon));
                     if (writeCoordinateData)
                     {
-                        var currentSerializerSettings = BackupSerializerSettings(serializer);
+                        var currentSerializerSettings = BackupSerializerSettings(writer);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, _serializerSettingsForCoordinates);
+                            ApplySerializerSettings(writer, _serializerSettingsForCoordinates);
                         }
                         writer.WritePropertyName("coordinates");
                         WritePolygonCoordinates(polygon);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, currentSerializerSettings);
+                            ApplySerializerSettings(writer, currentSerializerSettings);
                         }
                     }
 
@@ -230,10 +224,10 @@ namespace NetTopologySuite.IO.Converters
 
                     if (writeCoordinateData)
                     {
-                        var currentSerializerSettings = BackupSerializerSettings(serializer);
+                        var currentSerializerSettings = BackupSerializerSettings(writer);
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, _serializerSettingsForCoordinates);
+                            ApplySerializerSettings(writer, _serializerSettingsForCoordinates);
                         }
                         writer.WritePropertyName("coordinates");
                         writer.WriteStartArray();
@@ -242,7 +236,7 @@ namespace NetTopologySuite.IO.Converters
                         writer.WriteEndArray();
                         if (customCoordinateSerializeSettings)
                         {
-                            ApplySerializerSettings(serializer, currentSerializerSettings);
+                            ApplySerializerSettings(writer, currentSerializerSettings);
                         }
                     }
 

--- a/src/NetTopologySuite.IO.GeoJSON/GeoJsonSerializer.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/GeoJsonSerializer.cs
@@ -77,7 +77,7 @@ namespace NetTopologySuite.IO
         public static JsonSerializer CreateDefault(JsonSerializerSettings settings, JsonSerializerSettings settingsForCoordinates)
         {
             var s = Create(settings);
-            AddGeoJsonConverters(s, Wgs84Factory, 2, false);
+            AddGeoJsonConverters(s, Wgs84Factory, 2, false, settingsForCoordinates);
 
             return s;
         }

--- a/src/NetTopologySuite.IO.GeoJSON/GeoJsonSerializer.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/GeoJsonSerializer.cs
@@ -68,6 +68,23 @@ namespace NetTopologySuite.IO
         /// <summary>
         /// Factory method to create a (Geo)JsonSerializer
         /// </summary>
+        /// <returns>
+        /// A <see cref="JsonSerializer"/>.
+        /// </returns>
+        /// <remarks>
+        /// The <see cref="GeometryFactory"/> uses WGS-84.
+        /// </remarks>
+        public static JsonSerializer CreateDefault(JsonSerializerSettings settings, JsonSerializerSettings settingsForCoordinates)
+        {
+            var s = Create(settings);
+            AddGeoJsonConverters(s, Wgs84Factory, 2, false);
+
+            return s;
+        }
+
+        /// <summary>
+        /// Factory method to create a (Geo)JsonSerializer
+        /// </summary>
         /// <param name="factory">
         /// A factory to use when creating geometries. The factories <see cref="PrecisionModel"/>
         /// is also used to format <see cref="Coordinate.X"/> and <see cref="Coordinate.Y"/> of the coordinates.
@@ -162,7 +179,7 @@ namespace NetTopologySuite.IO
             AddGeoJsonConverters(s, factory, dimension, enforceRingOrientation);
             return s;
         }
-        private static void AddGeoJsonConverters(JsonSerializer s, GeometryFactory factory, int dimension, bool enforceRingOrientation)
+        private static void AddGeoJsonConverters(JsonSerializer s, GeometryFactory factory, int dimension, bool enforceRingOrientation, JsonSerializerSettings settingsForCoordinates = null)
         {
 #if DEBUG
             if (factory.SRID != 4326)
@@ -175,7 +192,7 @@ namespace NetTopologySuite.IO
             c.Add(new FeatureCollectionConverter());
             c.Add(new FeatureConverter());
             c.Add(new AttributesTableConverter());
-            c.Add(new GeometryConverter(factory, dimension, enforceRingOrientation));
+            c.Add(new GeometryConverter(factory, dimension, enforceRingOrientation, settingsForCoordinates));
             c.Add(new GeometryArrayConverter(factory, dimension));
             //c.Add(new CoordinateConverter(factory.PrecisionModel, dimension));
             c.Add(new EnvelopeConverter(factory.PrecisionModel));


### PR DESCRIPTION
Made some changes in the GeoJsonSerializer and in the GeometryConverter class that allows for a different formatting of the coordinates property on the Geometry classes in the json file.

For example, you can specify Formatting.Indented for the json in general, but put in a JsonSerializerSettings instance with Formatting.None for the writing of coordinates property.

Changes in GeoJsonSerializer:
* New CreateDefault overload that takes a secondary JsonSerializerSettiings instance.
* Added a parameter to the AddGeoJsonConverters class (default null) and passing this to the constructor of the GeometryConverter class.
* Added a constructor overload of GeometryConverter class taking in the extra JsonSerializerSettings instance and stores this in a member field.
* Added functions for backing up serializer settings and applying serializer settings.
* In the WriteJson function, when coordinates are written, then first backup the serializer settings from the writer. next apply the custom serializer settings if found and after writing coordinates, the backup of serializer settings are applied back to the writer