### PR TITLE
fixed GeometryConverter for empty geometries deserialization

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/Converters/GeometryConverter.cs
@@ -457,48 +457,50 @@ namespace NetTopologySuite.IO.Converters
                 throw new ArgumentException("Expected token '}' not found.");
             }
 
+            bool CoordsIsNullOrEmpty() => coords is null || coords.Count == 0;
+
             switch (geometryType)
             {
-                case GeoJsonObjectType.Point when coords is null:
+                case GeoJsonObjectType.Point when CoordsIsNullOrEmpty():
                     return _factory.CreatePoint();
 
                 case GeoJsonObjectType.Point:
                     return CreatePoint(reader, coords);
 
-                case GeoJsonObjectType.MultiPoint when coords is null:
+                case GeoJsonObjectType.MultiPoint when CoordsIsNullOrEmpty():
                     return _factory.CreateMultiPoint();
 
                 case GeoJsonObjectType.MultiPoint:
                     return _factory.CreateMultiPoint(coords.Select(obj => CreatePoint(reader, (List<object>)obj))
                         .ToArray());
 
-                case GeoJsonObjectType.LineString when coords is null:
+                case GeoJsonObjectType.LineString when CoordsIsNullOrEmpty():
                     return _factory.CreateLineString();
 
                 case GeoJsonObjectType.LineString:
                     return CreateLineString(reader, coords);
 
-                case GeoJsonObjectType.MultiLineString when coords is null:
+                case GeoJsonObjectType.MultiLineString when CoordsIsNullOrEmpty():
                     return _factory.CreateMultiLineString();
 
                 case GeoJsonObjectType.MultiLineString:
                     return _factory.CreateMultiLineString(coords
                         .Select(obj => CreateLineString(reader, (List<object>)obj)).ToArray());
 
-                case GeoJsonObjectType.Polygon when coords is null:
+                case GeoJsonObjectType.Polygon when CoordsIsNullOrEmpty():
                     return _factory.CreatePolygon();
 
                 case GeoJsonObjectType.Polygon:
                     return CreatePolygon(reader, coords);
 
-                case GeoJsonObjectType.MultiPolygon when coords is null:
+                case GeoJsonObjectType.MultiPolygon when CoordsIsNullOrEmpty():
                     return _factory.CreateMultiPolygon();
 
                 case GeoJsonObjectType.MultiPolygon:
                     return _factory.CreateMultiPolygon(coords.Select(obj => CreatePolygon(reader, (List<object>)obj))
                         .ToArray());
 
-                case GeoJsonObjectType.GeometryCollection when coords is null:
+                case GeoJsonObjectType.GeometryCollection when CoordsIsNullOrEmpty():
                     return _factory.CreateGeometryCollection();
 
                 case GeoJsonObjectType.GeometryCollection:

--- a/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssue96.cs
+++ b/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssue96.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
 using Newtonsoft.Json;
 
 using NUnit.Framework;
@@ -10,17 +11,16 @@ namespace NetTopologySuite.IO.GeoJSON.Test.Issues.NetTopologySuite.IO.GeoJSON
     [GeoJsonIssueNumber(96)]
     public sealed class GitHubIssue96
     {
-        private static void DoTest(string data)
+        private static T Deserialize<T>(string data)
         {
             var serializer = GeoJsonSerializer.CreateDefault();
             using var sr = new StringReader(data);
             using var jtr = new JsonTextReader(sr);
-            Assert.Throws<ArgumentOutOfRangeException>(
-                () => serializer.Deserialize<IFeature>(jtr));
+            return serializer.Deserialize<T>(jtr);
         }
 
         [Test]
-        public void TestInvalidPolygonWithNullCoordinatesDeserialization()
+        public void TestInvalidFeatureWithNullCoordinatesDeserialization()
         {
             const string data = @"{
 	""type"": ""Feature"",
@@ -43,12 +43,11 @@ namespace NetTopologySuite.IO.GeoJSON.Test.Issues.NetTopologySuite.IO.GeoJSON
 		]
 	}
 }";
-            DoTest(data);
-
+            Assert.Throws<ArgumentOutOfRangeException>(() => Deserialize<IFeature>(data));
         }
 
         [Test]
-        public void TestInvalidPolygonWithEmptyCoordinatesDeserialization()
+        public void TestInvalidFeatureWithEmptyCoordinatesDeserialization()
         {
             const string data = @"{
 	""type"": ""Feature"",
@@ -70,7 +69,123 @@ namespace NetTopologySuite.IO.GeoJSON.Test.Issues.NetTopologySuite.IO.GeoJSON
 		]
 	}
 }";
-            DoTest(data);
+            Assert.Throws<ArgumentOutOfRangeException>(() => Deserialize<IFeature>(data));
+        }
+
+        [Test]
+        public void TestValidFeatureWithEmptyCoordinatesDeserialization()
+        {
+            const string data = @"{
+	""type"": ""Feature"",
+	""id"": ""955r48cb-129f-44ce-a229-cbd065a67bcf"",
+	""properties"": {
+		""name"": ""test"",
+		""updated"": """",
+		""altitude"": 2657,
+		""longitude"": -116.425598,
+		""latitude"": 33.523399
+	},
+	""geometry"": {
+		""type"": ""Polygon"",
+		""coordinates"": []
+	}
+}";
+            var f = Deserialize<IFeature>(data);
+            Assert.That(f, Is.Not.Null);
+            Assert.That(f.Geometry, Is.Not.Null);
+            Assert.That(f.Geometry, Is.InstanceOf<Polygon>());
+            Assert.That(f.Geometry.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidPointEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""Point"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<Point>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidLineStringEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""LineString"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<LineString>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidPolygonEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""Polygon"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<Polygon>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidMultiPointEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""MultiPoint"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<MultiPoint>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidMultiLineStringEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""MultiLineString"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<MultiLineString>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidMultiPolygonEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""MultiPolygon"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<MultiPolygon>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidGeometryCollectionEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""GeometryCollection"",
+	""geometries"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<GeometryCollection>());
+            Assert.That(g.IsEmpty, Is.True);
         }
     }
 }

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue96.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue96.cs
@@ -1,21 +1,44 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Text.Json;
 using NetTopologySuite.Features;
-using NetTopologySuite.IO.GeoJSON4STJ.Test.Converters;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
 using NUnit.Framework;
 
 namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
 {
     [GeoJsonIssueNumber(96)]
-    public sealed class Issue96 : SandDTest<IFeature>
+    public sealed class Issue96
     {
-        private void DoTest(string data)
+        private GeoJsonConverterFactory GeoJsonConverterFactory { get; } = new GeoJsonConverterFactory();
+
+        private JsonSerializerOptions DefaultOptions
         {
-            Assert.Throws<JsonException>(
-                () => Deserialize(data, DefaultOptions));
+            get
+            {
+                var res = new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip };
+                res.Converters.Add(GeoJsonConverterFactory);
+                return res;
+            }
+        }
+
+        private T Deserialize<T>(string json)
+        {
+            byte[] buffer = Encoding.UTF8.GetBytes(json);
+            using var ms = new MemoryStream(buffer);
+            {
+                var b = new ReadOnlySpan<byte>(ms.ToArray());
+                var r = new Utf8JsonReader(b);
+                // we are at None
+                r.Read();
+                return JsonSerializer.Deserialize<T>(ref r, DefaultOptions);
+            }
         }
 
         [Test]
-        public void TestInvalidPolygonWithNullCoordinatesDeserialization()
+        public void TestInvalidFeatureWithNullCoordinatesDeserialization()
         {
             const string data = @"{
 	""type"": ""Feature"",
@@ -38,11 +61,11 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
 		]
 	}
 }";
-            DoTest(data);
+            Assert.Throws<JsonException>(() => Deserialize<IFeature>(data));
         }
 
         [Test]
-        public void TestInvalidPolygonWithEmptyCoordinatesDeserialization()
+        public void TestInvalidFeatureWithEmptyCoordinatesDeserialization()
         {
             const string data = @"{
 	""type"": ""Feature"",
@@ -64,7 +87,123 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
 		]
 	}
 }";
-            DoTest(data);
+            Assert.Throws<JsonException>(() => Deserialize<IFeature>(data));
+        }
+
+        [Test]
+        public void TestValidFeatureWithEmptyCoordinatesDeserialization()
+        {
+            const string data = @"{
+	""type"": ""Feature"",
+	""id"": ""955r48cb-129f-44ce-a229-cbd065a67bcf"",
+	""properties"": {
+		""name"": ""test"",
+		""updated"": """",
+		""altitude"": 2657,
+		""longitude"": -116.425598,
+		""latitude"": 33.523399
+	},
+	""geometry"": {
+		""type"": ""Polygon"",
+		""coordinates"": []
+	}
+}";
+            var f = Deserialize<IFeature>(data);
+            Assert.That(f, Is.Not.Null);
+            Assert.That(f.Geometry, Is.Not.Null);
+            Assert.That(f.Geometry, Is.InstanceOf<Polygon>());
+            Assert.That(f.Geometry.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidPointEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""Point"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<Point>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidLineStringEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""LineString"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<LineString>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidPolygonEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""Polygon"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<Polygon>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidMultiPointEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""MultiPoint"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<MultiPoint>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidMultiLineStringEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""MultiLineString"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<MultiLineString>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidMultiPolygonEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""MultiPolygon"",
+	""coordinates"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<MultiPolygon>());
+            Assert.That(g.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void TestValidGeometryCollectionEmptyDeserialization()
+        {
+            const string data = @"{
+	""type"": ""GeometryCollection"",
+	""geometries"": []
+}";
+            var g = Deserialize<Geometry>(data);
+            Assert.That(g, Is.Not.Null);
+            Assert.That(g, Is.InstanceOf<GeometryCollection>());
+            Assert.That(g.IsEmpty, Is.True);
         }
     }
 }


### PR DESCRIPTION
GeoJSON converter fix to correctly deserialize empty geometries, like 
```
{
	"type"" "Point",
	"coordinates": []
}
```
see also #96 for a bit more context