### PR TITLE
handled 'writebbox' parameters for features and featurecollections

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -31,7 +31,7 @@ namespace NetTopologySuite.IO.Converters
 
         private readonly GeometryFactory _factory;
 
-        private readonly bool _writeBBox;
+        private readonly bool _writeGeometryBBox;
 
         private readonly string _idPropertyName;
 
@@ -59,9 +59,9 @@ namespace NetTopologySuite.IO.Converters
         /// feature and feature collection, and defaults for all other values.
         /// </summary>
         /// <param name="factory"></param>
-        /// <param name="writeBBox"></param>
-        public GeoJsonConverterFactory(GeometryFactory factory, bool writeBBox)
-            : this(factory, writeBBox, DefaultIdPropertyName)
+        /// <param name="writeGeometryBBox"></param>
+        public GeoJsonConverterFactory(GeometryFactory factory, bool writeGeometryBBox)
+            : this(factory, writeGeometryBBox, DefaultIdPropertyName)
         {
         }
 
@@ -72,12 +72,12 @@ namespace NetTopologySuite.IO.Converters
         /// when an <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id".
         /// </summary>
         /// <param name="factory"></param>
-        /// <param name="writeBBox"></param>
+        /// <param name="writeGeometryBBox"></param>
         /// <param name="idPropertyName"></param>
-        public GeoJsonConverterFactory(GeometryFactory factory, bool writeBBox, string idPropertyName)
+        public GeoJsonConverterFactory(GeometryFactory factory, bool writeGeometryBBox, string idPropertyName)
         {
             _factory = factory;
-            _writeBBox = writeBBox;
+            _writeGeometryBBox = writeGeometryBBox;
             _idPropertyName = idPropertyName ?? DefaultIdPropertyName;
         }
 
@@ -94,11 +94,11 @@ namespace NetTopologySuite.IO.Converters
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             if (GeometryTypes.Contains(typeToConvert))
-                return new StjGeometryConverter(_factory, _writeBBox);
+                return new StjGeometryConverter(_factory, _writeGeometryBBox);
             if (typeToConvert == typeof(FeatureCollection))
-                return new StjFeatureCollectionConverter(_writeBBox);
+                return new StjFeatureCollectionConverter(_writeGeometryBBox);
             if (typeof(IFeature).IsAssignableFrom(typeToConvert))
-                return new StjFeatureConverter(_idPropertyName, _writeBBox);
+                return new StjFeatureConverter(_idPropertyName, _writeGeometryBBox);
             if (typeof(IAttributesTable).IsAssignableFrom(typeToConvert))
                 return new StjAttributesTableConverter(_idPropertyName);
 

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -97,9 +97,9 @@ namespace NetTopologySuite.IO.Converters
             if (GeometryTypes.Contains(typeToConvert))
                 return new StjGeometryConverter(_factory, _writeGeometryBBox);
             if (typeToConvert == typeof(FeatureCollection))
-                return new StjFeatureCollectionConverter();
+                return new StjFeatureCollectionConverter(_writeGeometryBBox);
             if (typeof(IFeature).IsAssignableFrom(typeToConvert))
-                return new StjFeatureConverter(_idPropertyName);
+                return new StjFeatureConverter(_idPropertyName, _writeGeometryBBox);
             if (typeof(IAttributesTable).IsAssignableFrom(typeToConvert))
                 return new StjAttributesTableConverter(_idPropertyName);
 

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NetTopologySuite.Features;
@@ -32,7 +31,7 @@ namespace NetTopologySuite.IO.Converters
 
         private readonly GeometryFactory _factory;
 
-        private readonly bool _writeGeometryBBox;
+        private readonly bool _writeBBox;
 
         private readonly string _idPropertyName;
 
@@ -56,29 +55,29 @@ namespace NetTopologySuite.IO.Converters
 
         /// <summary>
         /// Creates an instance of this class using the provided <see cref="GeometryFactory"/>, the
-        /// given value for whether or not we should write out a "bbox" for a plain geometry, and
-        /// defaults for all other values.
+        /// given value for whether or not we should write out a "bbox" for a plain geometry,
+        /// feature and feature collection, and defaults for all other values.
         /// </summary>
         /// <param name="factory"></param>
-        /// <param name="writeGeometryBBox"></param>
-        public GeoJsonConverterFactory(GeometryFactory factory, bool writeGeometryBBox)
-            : this(factory, writeGeometryBBox, DefaultIdPropertyName)
+        /// <param name="writeBBox"></param>
+        public GeoJsonConverterFactory(GeometryFactory factory, bool writeBBox)
+            : this(factory, writeBBox, DefaultIdPropertyName)
         {
         }
 
         /// <summary>
         /// Creates an instance of this class using the provided <see cref="GeometryFactory"/>, the
-        /// given value for whether or not we should write out a "bbox" for a plain geometry, and
-        /// the given "magic" string to signal when an <see cref="IAttributesTable"/> property is
-        /// actually filling in for a Feature's "id".
+        /// given value for whether or not we should write out a "bbox" for a plain geometry,
+        /// feature and feature collection, and the given "magic" string to signal
+        /// when an <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id".
         /// </summary>
         /// <param name="factory"></param>
-        /// <param name="writeGeometryBBox"></param>
+        /// <param name="writeBBox"></param>
         /// <param name="idPropertyName"></param>
-        public GeoJsonConverterFactory(GeometryFactory factory, bool writeGeometryBBox, string idPropertyName)
+        public GeoJsonConverterFactory(GeometryFactory factory, bool writeBBox, string idPropertyName)
         {
             _factory = factory;
-            _writeGeometryBBox = writeGeometryBBox;
+            _writeBBox = writeBBox;
             _idPropertyName = idPropertyName ?? DefaultIdPropertyName;
         }
 
@@ -95,11 +94,11 @@ namespace NetTopologySuite.IO.Converters
         public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
         {
             if (GeometryTypes.Contains(typeToConvert))
-                return new StjGeometryConverter(_factory, _writeGeometryBBox);
+                return new StjGeometryConverter(_factory, _writeBBox);
             if (typeToConvert == typeof(FeatureCollection))
-                return new StjFeatureCollectionConverter(_writeGeometryBBox);
+                return new StjFeatureCollectionConverter(_writeBBox);
             if (typeof(IFeature).IsAssignableFrom(typeToConvert))
-                return new StjFeatureConverter(_idPropertyName, _writeGeometryBBox);
+                return new StjFeatureConverter(_idPropertyName, _writeBBox);
             if (typeof(IAttributesTable).IsAssignableFrom(typeToConvert))
                 return new StjAttributesTableConverter(_idPropertyName);
 

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
@@ -11,6 +11,13 @@ namespace NetTopologySuite.IO.Converters
     /// </summary>
     internal class StjFeatureCollectionConverter : JsonConverter<FeatureCollection>
     {
+        private readonly bool _writeGeometryBBox;
+
+        public StjFeatureCollectionConverter(bool writeGeometryBBox)
+        {
+            _writeGeometryBBox = writeGeometryBBox;
+        }
+
         /// <summary>
         /// Reads the JSON representation of the object.
         /// </summary>
@@ -71,7 +78,8 @@ namespace NetTopologySuite.IO.Converters
             writer.WriteStartObject();
             writer.WriteString("type", nameof(GeoJsonObjectType.FeatureCollection));
 
-            StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, null);
+            if (_writeGeometryBBox)
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, null);
 
             writer.WriteStartArray("features");
             foreach (var feature in value)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
@@ -81,9 +81,9 @@ namespace NetTopologySuite.IO.Converters
             if (_writeGeometryBBox)
             {
                 var env = value.BoundingBox ?? new Envelope();
-                foreach (var features in value)
+                foreach (var feat in value)
                 {
-                    var curr = features.BoundingBox ?? features.Geometry?.EnvelopeInternal ?? new Envelope();
+                    var curr = feat.BoundingBox ?? feat.Geometry?.EnvelopeInternal ?? new Envelope();
                     env.ExpandToInclude(curr);
                 }
                 StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, env);

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
@@ -79,15 +79,7 @@ namespace NetTopologySuite.IO.Converters
             writer.WriteString("type", nameof(GeoJsonObjectType.FeatureCollection));
 
             if (_writeGeometryBBox)
-            {
-                var env = value.BoundingBox ?? new Envelope();
-                foreach (var feat in value)
-                {
-                    var curr = feat.BoundingBox ?? feat.Geometry?.EnvelopeInternal ?? new Envelope();
-                    env.ExpandToInclude(curr);
-                }
-                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, env);
-            }
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options);
 
             writer.WriteStartArray("features");
             foreach (var feature in value)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-
 using NetTopologySuite.Features;
 
 namespace NetTopologySuite.IO.Converters
@@ -11,11 +10,11 @@ namespace NetTopologySuite.IO.Converters
     /// </summary>
     internal class StjFeatureCollectionConverter : JsonConverter<FeatureCollection>
     {
-        private readonly bool _writeGeometryBBox;
+        private readonly bool _writeBBox;
 
-        public StjFeatureCollectionConverter(bool writeGeometryBBox)
+        public StjFeatureCollectionConverter(bool writeBBox)
         {
-            _writeGeometryBBox = writeGeometryBBox;
+            _writeBBox = writeBBox;
         }
 
         /// <summary>
@@ -78,7 +77,7 @@ namespace NetTopologySuite.IO.Converters
             writer.WriteStartObject();
             writer.WriteString("type", nameof(GeoJsonObjectType.FeatureCollection));
 
-            if (_writeGeometryBBox)
+            if (_writeBBox)
                 StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, null);
 
             writer.WriteStartArray("features");

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
@@ -11,11 +11,11 @@ namespace NetTopologySuite.IO.Converters
     /// </summary>
     internal class StjFeatureCollectionConverter : JsonConverter<FeatureCollection>
     {
-        private readonly bool _writeBBox;
+        private readonly bool _writeGeometryBBox;
 
-        public StjFeatureCollectionConverter(bool writeBBox)
+        public StjFeatureCollectionConverter(bool writeGeometryBBox)
         {
-            _writeBBox = writeBBox;
+            _writeGeometryBBox = writeGeometryBBox;
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace NetTopologySuite.IO.Converters
             writer.WriteStartObject();
             writer.WriteString("type", nameof(GeoJsonObjectType.FeatureCollection));
 
-            if (_writeBBox)
+            if (_writeGeometryBBox)
             {
                 var env = value.BoundingBox ?? new Envelope();
                 foreach (var features in value)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureCollectionConverter.cs
@@ -2,6 +2,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.Converters
 {
@@ -78,7 +79,15 @@ namespace NetTopologySuite.IO.Converters
             writer.WriteString("type", nameof(GeoJsonObjectType.FeatureCollection));
 
             if (_writeBBox)
-                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, null);
+            {
+                var env = value.BoundingBox ?? new Envelope();
+                foreach (var features in value)
+                {
+                    var curr = features.BoundingBox ?? features.Geometry?.EnvelopeInternal ?? new Envelope();
+                    env.ExpandToInclude(curr);
+                }
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, env);
+            }
 
             writer.WriteStartArray("features");
             foreach (var feature in value)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -48,7 +48,7 @@ namespace NetTopologySuite.IO.Converters
 
             // bbox (optional)
             if (_writeGeometryBBox)
-                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value?.Geometry?.EnvelopeInternal);
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value.Geometry?.EnvelopeInternal);
 
             // geometry
             if (value.Geometry != null || !options.IgnoreNullValues)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -48,7 +48,7 @@ namespace NetTopologySuite.IO.Converters
 
             // bbox (optional)
             if (_writeGeometryBBox)
-                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value.Geometry?.EnvelopeInternal);
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options);
 
             // geometry
             if (value.Geometry != null || !options.IgnoreNullValues)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 
@@ -13,12 +12,12 @@ namespace NetTopologySuite.IO.Converters
     internal sealed class StjFeatureConverter : JsonConverter<IFeature>
     {
         private readonly string _idPropertyName;
-        private readonly bool _writeGeometryBBox;
+        private readonly bool _writeBBox;
 
-        public StjFeatureConverter(string idPropertyName, bool writeGeometryBBox)
+        public StjFeatureConverter(string idPropertyName, bool writeBBox)
         {
             _idPropertyName = idPropertyName;
-            _writeGeometryBBox = writeGeometryBBox;
+            _writeBBox = writeBBox;
         }
 
         /// <summary>
@@ -48,7 +47,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             // bbox (optional)
-            if (_writeGeometryBBox)
+            if (_writeBBox)
                 StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value.Geometry);
 
             // geometry

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -12,12 +12,12 @@ namespace NetTopologySuite.IO.Converters
     internal sealed class StjFeatureConverter : JsonConverter<IFeature>
     {
         private readonly string _idPropertyName;
-        private readonly bool _writeBBox;
+        private readonly bool _writeGeometryBBox;
 
-        public StjFeatureConverter(string idPropertyName, bool writeBBox)
+        public StjFeatureConverter(string idPropertyName, bool writeGeometryBBox)
         {
             _idPropertyName = idPropertyName;
-            _writeBBox = writeBBox;
+            _writeGeometryBBox = writeGeometryBBox;
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             // bbox (optional)
-            if (_writeBBox)
+            if (_writeGeometryBBox)
                 StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value?.Geometry?.EnvelopeInternal);
 
             // geometry
@@ -58,7 +58,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             // properties
-            if (value.Attributes != null || ! options.IgnoreNullValues)
+            if (value.Attributes != null || !options.IgnoreNullValues)
             {
                 writer.WritePropertyName("properties");
                 JsonSerializer.Serialize(writer, value.Attributes, options);

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -13,10 +13,12 @@ namespace NetTopologySuite.IO.Converters
     internal sealed class StjFeatureConverter : JsonConverter<IFeature>
     {
         private readonly string _idPropertyName;
+        private readonly bool _writeGeometryBBox;
 
-        public StjFeatureConverter(string idPropertyName)
+        public StjFeatureConverter(string idPropertyName, bool writeGeometryBBox)
         {
             _idPropertyName = idPropertyName;
+            _writeGeometryBBox = writeGeometryBBox;
         }
 
         /// <summary>
@@ -46,8 +48,8 @@ namespace NetTopologySuite.IO.Converters
             }
 
             // bbox (optional)
-            var bbox = value.BoundingBox;
-            StjGeometryConverter.WriteBBox(writer, bbox, options, value.Geometry);
+            if (_writeGeometryBBox)
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value.Geometry);
 
             // geometry
             if (value.Geometry != null || !options.IgnoreNullValues)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -48,7 +48,7 @@ namespace NetTopologySuite.IO.Converters
 
             // bbox (optional)
             if (_writeBBox)
-                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value.Geometry);
+                StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options, value?.Geometry?.EnvelopeInternal);
 
             // geometry
             if (value.Geometry != null || !options.IgnoreNullValues)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
@@ -44,19 +44,19 @@ namespace NetTopologySuite.IO.Converters
             return res;
         }
 
-        internal static void WriteBBox(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options, Geometry geometry)
+        internal static void WriteBBox(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options, Envelope env)
         {
             // if we don't want to write "null" bounding boxes, bail out.
             if ((value == null || value.IsNull) && options.IgnoreNullValues)
                 return;
 
             // Don't clutter export with bounding box if geometry is a point!
-            if (geometry is Point)
+            if (env.Area == 0)
                 return;
 
             // if value == null, try to get it from geometry
             if (value == null)
-                value = geometry?.EnvelopeInternal ?? new Envelope();
+                value = env ?? new Envelope();
 
             writer.WritePropertyName("bbox");
             if (value.IsNull)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
@@ -1,10 +1,23 @@
-﻿using System.Text.Json;
+﻿using System;
+using System.Text.Json;
+using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.Converters
 {
     internal partial class StjGeometryConverter
     {
+        /// <summary>
+        /// Gets or sets a value indicating if the bounding box should be written for geometries
+        /// </summary>
+        /// <remarks>Property will be removed in future versions.</remarks>
+        [Obsolete("Property will be removed in future versions")]
+        public bool WriteGeometryBBox
+        {
+            get { return _writeGeometryBBox; }
+            set { _writeGeometryBBox = value; }
+        }
+
         internal static Envelope ReadBBox(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             Envelope res = null;
@@ -44,19 +57,36 @@ namespace NetTopologySuite.IO.Converters
             return res;
         }
 
-        internal static void WriteBBox(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options, Envelope env)
+        /// <summary>
+        /// Writes the BBOX to the given <paramref name="writer"/>.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="value">The "main" envelope, used if valid (i.e.: is not null).</param>
+        /// <param name="options">The serialization options.</param>
+        /// <param name="geometryEnvelope">
+        /// The "backup" envelope, used only if the <paramref name="value"/> is not valid (i.e.: is not null).
+        /// </param>
+        /// <remarks>
+        /// For a <see cref="Geometry"/>, both the <paramref name="value"/>
+        /// and the <paramref name="geometryEnvelope"/> are the <see cref="IFeature.Geometry"/> envelope.
+        /// For a <see cref="IFeature"/>, the <paramref name="value"/> is the <see cref="IFeature.BoundingBox"/>
+        /// and the <paramref name="geometryEnvelope"/> is the <see cref="IFeature.Geometry"/> envelope.
+        /// For a <see cref="FeatureCollection"/>, the <paramref name="value"/> is the <see cref="IFeature.BoundingBox"/>
+        /// and the <paramref name="geometryEnvelope"/> is the expanded envelope of all
+        /// the <see cref="IFeature.Geometry"/> envelopes that compose the feature collection.
+        /// </remarks>
+        internal static void WriteBBox(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options,
+            Envelope geometryEnvelope)
         {
             // if we don't want to write "null" bounding boxes, bail out.
-            if ((value == null || value.IsNull) && options.IgnoreNullValues)
+            if ((value?.IsNull != false) && options.IgnoreNullValues)
                 return;
-
-            // Don't clutter export with bounding box if geometry is a point!
-            if (env.Area == 0)
+            if ((geometryEnvelope?.IsNull != false) && options.IgnoreNullValues)
                 return;
 
             // if value == null, try to get it from geometry
             if (value == null)
-                value = env ?? new Envelope();
+                value = geometryEnvelope ?? new Envelope();
 
             writer.WritePropertyName("bbox");
             if (value.IsNull)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
@@ -5,11 +5,6 @@ namespace NetTopologySuite.IO.Converters
 {
     internal partial class StjGeometryConverter
     {
-        /// <summary>
-        /// Gets or sets a value indicating if the bounding box should be written for geometries
-        /// </summary>
-        public bool WriteGeometryBBox { get; set; }
-
         internal static Envelope ReadBBox(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             Envelope res = null;

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
@@ -1,23 +1,11 @@
 ﻿using System;
 using System.Text.Json;
-using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.Converters
 {
     internal partial class StjGeometryConverter
     {
-        /// <summary>
-        /// Gets or sets a value indicating if the bounding box should be written for geometries
-        /// </summary>
-        /// <remarks>Property will be removed in future versions.</remarks>
-        [Obsolete("Property will be removed in future versions")]
-        public bool WriteGeometryBBox
-        {
-            get { return _writeGeometryBBox; }
-            set { _writeGeometryBBox = value; }
-        }
-
         internal static Envelope ReadBBox(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             Envelope res = null;
@@ -61,32 +49,15 @@ namespace NetTopologySuite.IO.Converters
         /// Writes the BBOX to the given <paramref name="writer"/>.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        /// <param name="value">The "main" envelope, used if valid (i.e.: is not null).</param>
+        /// <param name="value">The envelope.</param>
         /// <param name="options">The serialization options.</param>
-        /// <param name="geometryEnvelope">
-        /// The "backup" envelope, used only if the <paramref name="value"/> is not valid (i.e.: is not null).
-        /// </param>
-        /// <remarks>
-        /// For a <see cref="Geometry"/>, both the <paramref name="value"/>
-        /// and the <paramref name="geometryEnvelope"/> are the <see cref="IFeature.Geometry"/> envelope.
-        /// For a <see cref="IFeature"/>, the <paramref name="value"/> is the <see cref="IFeature.BoundingBox"/>
-        /// and the <paramref name="geometryEnvelope"/> is the <see cref="IFeature.Geometry"/> envelope.
-        /// For a <see cref="FeatureCollection"/>, the <paramref name="value"/> is the <see cref="IFeature.BoundingBox"/>
-        /// and the <paramref name="geometryEnvelope"/> is the expanded envelope of all
-        /// the <see cref="IFeature.Geometry"/> envelopes that compose the feature collection.
-        /// </remarks>
-        internal static void WriteBBox(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options,
-            Envelope geometryEnvelope)
+        internal static void WriteBBox(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options)
         {
             // if we don't want to write "null" bounding boxes, bail out.
             if ((value?.IsNull != false) && options.IgnoreNullValues)
                 return;
-            if ((geometryEnvelope?.IsNull != false) && options.IgnoreNullValues)
-                return;
 
-            // if value == null, try to get it from geometry
-            if (value == null)
-                value = geometryEnvelope ?? new Envelope();
+            value = value ?? new Envelope();
 
             writer.WritePropertyName("bbox");
             if (value.IsNull)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -38,17 +38,17 @@ namespace NetTopologySuite.IO.Converters
         */
         private readonly GeometryFactory _geometryFactory;
 
-        private readonly bool _writeGeometryBBox;
+        private readonly bool _writeBBox;
 
         /// <summary>
         /// Creates an instance of this class
         /// </summary>
         /// <param name="geometryFactory">The geometry factory to use.</param>
-        /// <param name="writeGeometryBBox">Whether or not to write "bbox" with the geometry.</param>
-        public StjGeometryConverter(GeometryFactory geometryFactory, bool writeGeometryBBox)
+        /// <param name="writeBBox">Whether or not to write "bbox" with the geometry.</param>
+        public StjGeometryConverter(GeometryFactory geometryFactory, bool writeBBox)
         {
             _geometryFactory = geometryFactory ?? DefaultGeometryFactory;
-            _writeGeometryBBox = writeGeometryBBox;
+            _writeBBox = writeBBox;
         }
 
         public override Geometry Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -229,7 +229,7 @@ namespace NetTopologySuite.IO.Converters
                 }
             }
 
-            if (_writeGeometryBBox)
+            if (_writeBBox)
                 WriteBBox(writer, value.EnvelopeInternal, options, value);
 
             writer.WriteEndObject();

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -230,7 +230,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             if (_writeGeometryBBox)
-                WriteBBox(writer, value.EnvelopeInternal, options, value?.EnvelopeInternal);
+                WriteBBox(writer, value.EnvelopeInternal, options, value.EnvelopeInternal);
 
             writer.WriteEndObject();
         }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -230,7 +230,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             if (_writeGeometryBBox)
-                WriteBBox(writer, value.EnvelopeInternal, options, value.EnvelopeInternal);
+                WriteBBox(writer, value.EnvelopeInternal, options);
 
             writer.WriteEndObject();
         }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -230,7 +230,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             if (_writeBBox)
-                WriteBBox(writer, value.EnvelopeInternal, options, value);
+                WriteBBox(writer, value.EnvelopeInternal, options, value?.EnvelopeInternal);
 
             writer.WriteEndObject();
         }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -38,7 +38,7 @@ namespace NetTopologySuite.IO.Converters
         */
         private readonly GeometryFactory _geometryFactory;
 
-        private bool _writeGeometryBBox;
+        private readonly bool _writeGeometryBBox;
 
         /// <summary>
         /// Creates an instance of this class

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.cs
@@ -38,17 +38,17 @@ namespace NetTopologySuite.IO.Converters
         */
         private readonly GeometryFactory _geometryFactory;
 
-        private readonly bool _writeBBox;
+        private bool _writeGeometryBBox;
 
         /// <summary>
         /// Creates an instance of this class
         /// </summary>
         /// <param name="geometryFactory">The geometry factory to use.</param>
-        /// <param name="writeBBox">Whether or not to write "bbox" with the geometry.</param>
-        public StjGeometryConverter(GeometryFactory geometryFactory, bool writeBBox)
+        /// <param name="writeGeometryBBox">Whether or not to write "bbox" with the geometry.</param>
+        public StjGeometryConverter(GeometryFactory geometryFactory, bool writeGeometryBBox)
         {
             _geometryFactory = geometryFactory ?? DefaultGeometryFactory;
-            _writeBBox = writeBBox;
+            _writeGeometryBBox = writeGeometryBBox;
         }
 
         public override Geometry Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
@@ -229,7 +229,7 @@ namespace NetTopologySuite.IO.Converters
                 }
             }
 
-            if (_writeBBox)
+            if (_writeGeometryBBox)
                 WriteBBox(writer, value.EnvelopeInternal, options, value?.EnvelopeInternal);
 
             writer.WriteEndObject();

--- a/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssue100.cs
+++ b/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssue100.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using Newtonsoft.Json;
+
+using NUnit.Framework;
+
+namespace NetTopologySuite.IO.GeoJSON.Test.Issues.NetTopologySuite.IO.GeoJSON
+{
+    [GeoJsonIssueNumber(100)]
+    public sealed class GitHubIssue100
+    {
+        private static string Serialize(object obj)
+        {
+            var settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Include };
+            var serializer = GeoJsonSerializer.CreateDefault(settings);
+            var sb = new StringBuilder();
+            using var sw = new StringWriter(sb);
+            using var jtw = new JsonTextWriter(sw);
+            serializer.Serialize(jtw, obj);
+            return sb.ToString();
+        }
+
+        private const StringComparison StrCmp = StringComparison.InvariantCultureIgnoreCase;
+
+        private static readonly Geometry Geom = GeometryFactory.Default
+            .CreatePolygon(new Coordinate[]
+            {
+                new Coordinate(-89.863283,47.963199),
+                new Coordinate(-89.862819,47.963009),
+                new Coordinate(-89.86361,47.961897),
+                new Coordinate(-89.863596,47.963326),
+                new Coordinate(-89.863283,47.963199)
+            });
+
+        [Test]
+        public void BBOXIsNotWrittenForGeoms()
+        {
+            string geomJson = Serialize(Geom);
+            Assert.AreEqual(false, geomJson.Contains("bbox", StrCmp));
+        }
+
+        [Test]
+        public void BBOXIsWrittenForFeaturesAndColls()
+        {
+            var feature = new Feature(Geom, new AttributesTable { { "id", 1 }, { "test", "2" } });
+            string featureJson = Serialize(feature);
+            Assert.AreEqual(true, featureJson.Contains("bbox", StrCmp));
+            var featureColl = new FeatureCollection { feature };
+            string featureCollJson = Serialize(featureColl);
+            Assert.AreEqual(true, featureCollJson.Contains("bbox", StrCmp));
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureCollectionConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureCollectionConverterTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue100.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue100.cs
@@ -45,9 +45,33 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
             var feature = new Feature(geom, new AttributesTable { { "id", 1 }, { "test", "2" } });
             string featureJson = JsonSerializer.Serialize(feature, options);
             Assert.AreEqual(writeBBOX, featureJson.Contains("bbox", StrCmp));
+            if (writeBBOX)
+                Assert.That(featureJson.IndexOf("null", StrCmp), Is.EqualTo(-1));
             var featureColl = new FeatureCollection { feature };
             string featureCollJson = JsonSerializer.Serialize(featureColl, options);
             Assert.AreEqual(writeBBOX, featureCollJson.Contains("bbox", StrCmp));
+            if (writeBBOX)
+                Assert.That(featureCollJson.IndexOf("null", StrCmp), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public void BBOXForPointShoundNeverBeWrittem()
+        {
+            var fac = GeometryFactory.Default;
+            var geom = fac.CreatePoint(new Coordinate(-89.863283, 47.963199));
+            var options = new JsonSerializerOptions()
+            {
+                IgnoreNullValues = false,
+                Converters = { new GeoJsonConverterFactory(fac, true) }
+            };
+            string geomJson = JsonSerializer.Serialize(geom, options);
+            Assert.That(geomJson.Contains("bbox", StrCmp), Is.False);
+            var feature = new Feature(geom, new AttributesTable { { "id", 1 }, { "test", "2" } });
+            string featureJson = JsonSerializer.Serialize(feature, options);
+            Assert.That(featureJson.Contains("bbox", StrCmp), Is.False);
+            var featureColl = new FeatureCollection { feature };
+            string featureCollJson = JsonSerializer.Serialize(featureColl, options);
+            Assert.That(featureCollJson.Contains("bbox", StrCmp), Is.False);
         }
     }
 }

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue100.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue100.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Text.Json;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
+using NUnit.Framework;
+
+namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
+{
+    [GeoJsonIssueNumber(100)]
+    public sealed class Issue100
+    {
+        private const StringComparison StrCmp = StringComparison.InvariantCultureIgnoreCase;
+
+        [Test]
+        public void BBOXesShouldBeWritten()
+        {
+            DoBBOXTest(true);
+        }
+
+        [Test]
+        public void BBOXesShouldNotBeWritten()
+        {
+            DoBBOXTest(false);
+        }
+
+        private static void DoBBOXTest(bool writeBBOX)
+        {
+            var fac = GeometryFactory.Default;
+            var geom = fac.CreatePolygon(new Coordinate[]
+            {
+                new Coordinate(-89.863283,47.963199),
+                new Coordinate(-89.862819,47.963009),
+                new Coordinate(-89.86361,47.961897),
+                new Coordinate(-89.863596,47.963326),
+                new Coordinate(-89.863283,47.963199)
+            });
+            var options = new JsonSerializerOptions()
+            {
+                IgnoreNullValues = false,
+                Converters = { new GeoJsonConverterFactory(fac, writeBBOX) }
+            };
+            string geomJson = JsonSerializer.Serialize(geom, options);
+            Assert.AreEqual(writeBBOX, geomJson.Contains("bbox", StrCmp));
+            var feature = new Feature(geom, new AttributesTable { { "id", 1 }, { "test", "2" } });
+            string featureJson = JsonSerializer.Serialize(feature, options);
+            Assert.AreEqual(writeBBOX, featureJson.Contains("bbox", StrCmp));
+            var featureColl = new FeatureCollection { feature };
+            string featureCollJson = JsonSerializer.Serialize(featureColl, options);
+            Assert.AreEqual(writeBBOX, featureCollJson.Contains("bbox", StrCmp));
+        }
+    }
+}

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue100.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue100.cs
@@ -13,6 +13,7 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
         private const StringComparison StrCmp = StringComparison.InvariantCultureIgnoreCase;
 
         private static readonly GeometryFactory GF = GeometryFactory.Default;
+
         private static readonly Geometry Poly = GF.CreatePolygon(
             new Coordinate[]
             {
@@ -22,86 +23,137 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
                     new Coordinate(-89.863596,47.963326),
                     new Coordinate(-89.863283,47.963199)
             });
-        private static readonly Geometry Pt = GF.CreatePoint(
+        private static readonly Geometry Pnt = GF.CreatePoint(
             new Coordinate(-80, 40));
         private static readonly Geometry Coll = GF.CreateGeometryCollection(
-            new[] { Poly, Pt });
+            new[] { Poly, Pnt });
         private static readonly Geometry CollSamePoints = GF.CreateGeometryCollection(
-            new[] { Pt, Pt.Copy(), Pt.Copy(), Pt.Copy(), Pt.Copy() });
+            new[] { Pnt, Pnt.Copy(), Pnt.Copy(), Pnt.Copy(), Pnt.Copy() });
+        private static readonly Geometry Empty = GF.CreatePoint();
 
-        private static void DoBBOXTest(Geometry geom, bool writeBBOX)
+        private static void DoBBOXTest(Geometry g, bool writeBBOX, bool ignoreNull)
         {
-            Assert.That(geom, Is.Not.Null);
+            Assert.That(g, Is.Not.Null);
             var options = new JsonSerializerOptions()
             {
-                IgnoreNullValues = false,
+                IgnoreNullValues = ignoreNull,
                 Converters = { new GeoJsonConverterFactory(GF, writeBBOX) }
             };
-            string geomJson = JsonSerializer.Serialize(geom, options);
+            string geomJson = JsonSerializer.Serialize(g, options);
             Console.WriteLine($"GEOM: {geomJson}");
             Assert.AreEqual(writeBBOX, geomJson.Contains("bbox", StrCmp));
 
-            var feature = new Feature(geom, new AttributesTable { { "id", 1 }, { "test", "2" } });
+            var feature = new Feature(g, new AttributesTable { { "id", 1 }, { "test", "2" } });
             string featureJson = JsonSerializer.Serialize(feature, options);
             Console.WriteLine($"FEAT: {featureJson}");
             Assert.AreEqual(writeBBOX, featureJson.Contains("bbox", StrCmp));
             if (writeBBOX)
-                Assert.That(featureJson.IndexOf("null", StrCmp), Is.EqualTo(-1));
+            {
+                if (!ignoreNull && g.IsEmpty)
+                {
+                    Assert.That(featureJson.IndexOf("null", StrCmp), Is.Not.EqualTo(-1));
+                }
+                else
+                {
+                    Assert.That(featureJson.IndexOf("null", StrCmp), Is.EqualTo(-1));
+                }
+            }
 
             var featureColl = new FeatureCollection { feature };
             string featureCollJson = JsonSerializer.Serialize(featureColl, options);
             Console.WriteLine($"COLL: {featureCollJson}");
             Assert.AreEqual(writeBBOX, featureCollJson.Contains("bbox", StrCmp));
             if (writeBBOX)
-                Assert.That(featureCollJson.IndexOf("null", StrCmp), Is.EqualTo(-1));
+            {
+                if (!ignoreNull && g.IsEmpty)
+                {
+                    Assert.That(featureCollJson.IndexOf("null", StrCmp), Is.Not.EqualTo(-1));
+                }
+                else
+                {
+                    Assert.That(featureCollJson.IndexOf("null", StrCmp), Is.EqualTo(-1));
+                }
+            }
         }
 
         [Test]
         public void BBOXForPolygonShouldBeWritten()
         {
-            DoBBOXTest(Poly, true);
+            DoBBOXTest(g: Poly, writeBBOX: true, ignoreNull: false);
+            DoBBOXTest(g: Poly, writeBBOX: true, ignoreNull: true);
         }
 
         [Test]
         public void BBOXForPolygonShouldNotBeWritten()
         {
-            DoBBOXTest(Poly, false);
+            DoBBOXTest(g: Poly, writeBBOX: false, ignoreNull: false);
+            DoBBOXTest(g: Poly, writeBBOX: false, ignoreNull: true);
         }
 
         [Test]
         public void BBOXForPointShouldNotBeWrittenEvenIfBBoxFlagIsTrue()
         {
-            DoBBOXTest(Pt, true);
+            DoBBOXTest(g: Pnt, writeBBOX: true, ignoreNull: false);
+            DoBBOXTest(g: Pnt, writeBBOX: true, ignoreNull: true);
         }
 
         [Test]
         public void BBOXForPointShouldNotBeWritten()
         {
-            DoBBOXTest(Pt, false);
+            DoBBOXTest(g: Pnt, writeBBOX: false, ignoreNull: false);
+            DoBBOXTest(g: Pnt, writeBBOX: false, ignoreNull: true);
         }
 
         [Test]
         public void BBOXForGeomCollShouldBeWritten()
         {
-            DoBBOXTest(Coll, true);
+            DoBBOXTest(g: Coll, writeBBOX: true, ignoreNull: false);
+            DoBBOXTest(g: Coll, writeBBOX: true, ignoreNull: true);
         }
 
         [Test]
         public void BBOXForGeomCollShouldNotBeWritten()
         {
-            DoBBOXTest(Coll, false);
+            DoBBOXTest(g: Coll, writeBBOX: false, ignoreNull: false);
+            DoBBOXTest(g: Coll, writeBBOX: false, ignoreNull: true);
         }
 
         [Test]
         public void BBOXForGeomCollMadeOfSamePointsShouldBeWritten()
         {
-            DoBBOXTest(CollSamePoints, true);
+            DoBBOXTest(g: CollSamePoints, writeBBOX: true, ignoreNull: false);
+            DoBBOXTest(g: CollSamePoints, writeBBOX: true, ignoreNull: true);
         }
 
         [Test]
-        public void BBOXForGeomCollMadeOfSamePointsShouldNotBeWritten()
+        public void NullBBOXForGeomCollMadeOfSamePointsShouldNotBeWritten()
         {
-            DoBBOXTest(CollSamePoints, false);
+            DoBBOXTest(g: CollSamePoints, writeBBOX: false, ignoreNull: false);
+            DoBBOXTest(g: CollSamePoints, writeBBOX: false, ignoreNull: true);
+        }
+
+        [Test]
+        public void BBOXForEmptyGeomShouldBeWritten()
+        {
+            DoBBOXTest(g: Empty, writeBBOX: true, ignoreNull: false);
+        }
+
+        [Test]
+        public void BBOXForEmptyGeomShouldNotBeWritten()
+        {
+            DoBBOXTest(g: Empty, writeBBOX: false, ignoreNull: false);
+        }
+
+        [Test]
+        public void NullBBOXForEmptyGeomShouldBeIgnored()
+        {
+            DoBBOXTest(g: Empty, writeBBOX: true, ignoreNull: true);
+        }
+
+        [Test]
+        public void NullBBOXForEmptyGeomShouldBeNotIgnored()
+        {
+            DoBBOXTest(g: Empty, writeBBOX: true, ignoreNull: false);
         }
     }
 }


### PR DESCRIPTION
to fix #100 

actually, [GeoJSON specs](https://datatracker.ietf.org/doc/html/rfc7946#section-5) say that bbox is an optional parameter, so the idea is to extent the meaining of the "GeoJsonConverterFactory.writeGeometryBBox"  configuration parameter to handle anso `Feature` and `FeatureCollection` bboxes.