### PR TITLE
Support a variant of JsonElementAttributesTable that can be modified in-place, at a cost to reading performance.

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -72,7 +72,9 @@ namespace NetTopologySuite.IO.Converters
         /// <summary>
         /// Creates an instance of this class using the provided <see cref="GeometryFactory"/>, the
         /// given value for whether or not we should write out a "bbox" for a plain geometry,
-        /// feature and feature collection, and defaults for all other values.
+        /// feature and feature collection, the given "magic" string to signal when an
+        /// <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id", and
+        /// defaults for all other values.
         /// </summary>
         /// <param name="factory"></param>
         /// <param name="writeGeometryBBox"></param>
@@ -85,8 +87,10 @@ namespace NetTopologySuite.IO.Converters
         /// <summary>
         /// Creates an instance of this class using the provided <see cref="GeometryFactory"/>, the
         /// given value for whether or not we should write out a "bbox" for a plain geometry,
-        /// feature and feature collection, and the given "magic" string to signal
-        /// when an <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id".
+        /// feature and feature collection, the given "magic" string to signal when an
+        /// <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id", the
+        /// <see cref="RingOrientationOption"/> value that indicates how rings should be oriented
+        /// when writing them out, and defaults for all other values.
         /// </summary>
         /// <param name="factory"></param>
         /// <param name="writeGeometryBBox"></param>
@@ -101,8 +105,11 @@ namespace NetTopologySuite.IO.Converters
         /// <summary>
         /// Creates an instance of this class using the provided <see cref="GeometryFactory"/>, the
         /// given value for whether or not we should write out a "bbox" for a plain geometry,
-        /// feature and feature collection, and the given "magic" string to signal
-        /// when an <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id".
+        /// feature and feature collection, the given "magic" string to signal when an
+        /// <see cref="IAttributesTable"/> property is actually filling in for a Feature's "id", the
+        /// <see cref="RingOrientationOption"/> value that indicates how rings should be oriented
+        /// when writing them out, and a flag indicating whether or not to use a less efficient
+        /// implementation of <see cref="IAttributesTable"/> that can be modified in-place.
         /// </summary>
         /// <param name="factory"></param>
         /// <param name="writeGeometryBBox"></param>

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -133,13 +133,10 @@ namespace NetTopologySuite.IO.Converters
         {
             if (GeometryTypes.Contains(typeToConvert))
                 return new StjGeometryConverter(_factory, _writeGeometryBBox, _ringOrientationOption);
-
             if (typeToConvert == typeof(FeatureCollection))
                 return new StjFeatureCollectionConverter(_writeGeometryBBox);
-
             if (typeof(IFeature).IsAssignableFrom(typeToConvert))
                 return new StjFeatureConverter(_idPropertyName, _writeGeometryBBox);
-
             if (typeof(IAttributesTable).IsAssignableFrom(typeToConvert))
                 return new StjAttributesTableConverter(_idPropertyName, _allowModifyingAttributesTables);
 

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/IPartiallyDeserializedAttributesTable.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/IPartiallyDeserializedAttributesTable.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+
+namespace NetTopologySuite.Features
+{
+    /// <summary>
+    /// An <see cref="IAttributesTable"/> that has been <b>partially</b> deserialized to a strongly-
+    /// typed CLR object model, but which still contains some remnants of the JSON source that
+    /// produced it which may require the consumer to tell us more about what types they expected.
+    /// <para/>
+    /// Due to an intentional limitation in <c>System.Text.Json</c>, there is no way to produce a
+    /// standalone GeoJSON object that includes enough information to produce an object graph that's
+    /// complete with nested members of arbitrary types.
+    /// <para/>
+    /// In that spirit, this interface allows you to pick up where this library left off and use the
+    /// Feature's attributes in a more strongly-typed fashion using your own knowledge of whatever
+    /// internal structure the GeoJSON object is expected to have.
+    /// </summary>
+    public interface IPartiallyDeserializedAttributesTable : IAttributesTable
+    {
+        /// <summary>
+        /// Attempts to convert this entire table to a strongly-typed CLR object.
+        /// <para>
+        /// Modifications to the result <b>WILL NOT</b> propagate back to this table, or vice-versa.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of object to convert to.
+        /// </typeparam>
+        /// <param name="options">
+        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization.
+        /// </param>
+        /// <param name="deserialized">
+        /// Receives the converted value on success, or the default value on failure.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether or not the conversion succeeded.
+        /// </returns>
+        bool TryDeserializeJsonObject<T>(JsonSerializerOptions options, out T deserialized);
+
+        /// <summary>
+        /// Attempts to get a strongly-typed CLR object that corresponds to a single property that's
+        /// present in this table.
+        /// <para>
+        /// Modifications to the result <b>WILL NOT</b> propagate back to this table, or vice-versa.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of object to retrieve.
+        /// </typeparam>
+        /// <param name="propertyName">
+        /// The name of the property in this table to get as the specified type.
+        /// </param>
+        /// <param name="options">
+        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization.
+        /// </param>
+        /// <param name="deserialized">
+        /// Receives the converted value on success, or the default value on failure.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether or not the conversion succeeded.
+        /// </returns>
+        bool TryGetJsonObjectPropertyValue<T>(string propertyName, JsonSerializerOptions options, out T deserialized);
+    }
+}

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonArrayInAttributesTableWrapper.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonArrayInAttributesTableWrapper.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -63,10 +64,7 @@ namespace NetTopologySuite.Features
 
         public IEnumerator<object> GetEnumerator()
         {
-            foreach (JsonNode node in _array)
-            {
-                yield return Utility.ObjectFromJsonNode(node, _serializerOptions);
-            }
+            return _array.Select(node => Utility.ObjectFromJsonNode(node, _serializerOptions)).GetEnumerator();
         }
 
         public int IndexOf(object item)

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonArrayInAttributesTableWrapper.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonArrayInAttributesTableWrapper.cs
@@ -1,0 +1,116 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+using NetTopologySuite.IO.Converters;
+
+namespace NetTopologySuite.Features
+{
+    internal sealed class JsonArrayInAttributesTableWrapper : IList<object>, IReadOnlyList<object>
+    {
+        private readonly JsonArray _array;
+
+        private readonly JsonSerializerOptions _serializerOptions;
+
+        public JsonArrayInAttributesTableWrapper(JsonArray array, JsonSerializerOptions serializerOptions)
+        {
+            _array = array;
+            _serializerOptions = serializerOptions;
+        }
+
+        public object this[int index]
+        {
+            get => Utility.ObjectFromJsonNode(_array[index], _serializerOptions);
+            set => _array[index] = Utility.ObjectToJsonNode(value, _serializerOptions);
+        }
+
+        public int Count => _array.Count;
+
+        bool ICollection<object>.IsReadOnly => false;
+
+        public void Add(object item)
+        {
+            _array.Add(Utility.ObjectToJsonNode(item, _serializerOptions));
+        }
+
+        public void Clear()
+        {
+            _array.Clear();
+        }
+
+        public bool Contains(object item)
+        {
+            foreach (JsonNode node in _array)
+            {
+                object obj = Utility.ObjectFromJsonNode(node, _serializerOptions);
+                if (Equals(item, obj))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void CopyTo(object[] array, int arrayIndex)
+        {
+            foreach (JsonNode node in _array)
+            {
+                array[arrayIndex++] = Utility.ObjectFromJsonNode(node, _serializerOptions);
+            }
+        }
+
+        public IEnumerator<object> GetEnumerator()
+        {
+            foreach (JsonNode node in _array)
+            {
+                yield return Utility.ObjectFromJsonNode(node, _serializerOptions);
+            }
+        }
+
+        public int IndexOf(object item)
+        {
+            for (int i = 0; i < _array.Count; i++)
+            {
+                object obj = Utility.ObjectFromJsonNode(_array[i], _serializerOptions);
+                if (Equals(item, obj))
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        public void Insert(int index, object item)
+        {
+            _array.Insert(index, Utility.ObjectToJsonNode(item, _serializerOptions));
+        }
+
+        public bool Remove(object item)
+        {
+            for (int i = 0; i < _array.Count; i++)
+            {
+                object obj = Utility.ObjectFromJsonNode(_array[i], _serializerOptions);
+                if (Equals(item, obj))
+                {
+                    _array.RemoveAt(i);
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public void RemoveAt(int index)
+        {
+            _array.RemoveAt(index);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonArrayInAttributesTableWrapper.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonArrayInAttributesTableWrapper.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -106,7 +105,7 @@ namespace NetTopologySuite.Features
             _array.RemoveAt(index);
         }
 
-        IEnumerator IEnumerable.GetEnumerator()
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
             return GetEnumerator();
         }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonElementAttributesTable.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonElementAttributesTable.cs
@@ -19,7 +19,7 @@ namespace NetTopologySuite.Features
     /// JSON <see cref="JsonValueKind.Object"/>-valued properties are wrapped in their own
     /// <see cref="JsonElementAttributesTable"/> objects.
     /// </remarks>
-    public sealed class JsonElementAttributesTable : IAttributesTable
+    public sealed class JsonElementAttributesTable : IPartiallyDeserializedAttributesTable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonElementAttributesTable"/> class.
@@ -119,62 +119,13 @@ namespace NetTopologySuite.Features
                               .ToArray();
         }
 
-        /// <summary>
-        /// Attempts to convert this table to a strongly-typed value.
-        /// <para>
-        /// This is essentially just a way of calling
-        /// <see cref="JsonSerializer.Deserialize{TValue}(ref Utf8JsonReader, JsonSerializerOptions)"/>
-        /// on a Feature's <c>"properties"</c> object.
-        /// </para>
-        /// <para>
-        /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
-        /// automatically, for security reasons, so this is the workaround for now.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="T">
-        /// The type of object to convert to.
-        /// </typeparam>
-        /// <param name="options">
-        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization.
-        /// </param>
-        /// <param name="deserialized">
-        /// Receives the converted value on success, or the default value on failure.
-        /// </param>
-        /// <returns>
-        /// A value indicating whether or not the conversion succeeded.
-        /// </returns>
+        /// <inheritdoc />
         public bool TryDeserializeJsonObject<T>(JsonSerializerOptions options, out T deserialized)
         {
             return TryDeserializeElement(this.RootElement, options, out deserialized);
         }
 
-        /// <summary>
-        /// Attempts to get a strongly-typed value for that corresponds to a property of this table.
-        /// <para>
-        /// This is essentially just a way of calling
-        /// <see cref="JsonSerializer.Deserialize{TValue}(ref Utf8JsonReader, JsonSerializerOptions)"/>
-        /// on one of the individual items from a Feature's <c>"properties"</c>.
-        /// </para>
-        /// <para>
-        /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
-        /// automatically, for security reasons, so this is the workaround for now.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="T">
-        /// The type of object to retrieve.
-        /// </typeparam>
-        /// <param name="propertyName">
-        /// The name of the property in this table to get as the specified type.
-        /// </param>
-        /// <param name="options">
-        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization.
-        /// </param>
-        /// <param name="deserialized">
-        /// Receives the converted value on success, or the default value on failure.
-        /// </param>
-        /// <returns>
-        /// A value indicating whether or not the conversion succeeded.
-        /// </returns>
+        /// <inheritdoc />
         public bool TryGetJsonObjectPropertyValue<T>(string propertyName, JsonSerializerOptions options, out T deserialized)
         {
             if (!this.RootElement.TryGetProperty(propertyName, out var elementToTransform))

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonElementAttributesTable.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonElementAttributesTable.cs
@@ -102,6 +102,8 @@ namespace NetTopologySuite.Features
 
             set
             {
+                // TODO: get some workable serialization options in here, possibly the same ones we
+                // used when we deserialized this table in the first place?
                 WritableObject[attributeName] = value is null
                     ? null
                     : JsonSerializer.SerializeToNode(value, value.GetType());
@@ -185,7 +187,11 @@ namespace NetTopologySuite.Features
         /// <inheritdoc />
         public void Add(string attributeName, object value)
         {
-            WritableObject.Add(attributeName, value is null ? null : JsonSerializer.SerializeToNode(value, value.GetType()));
+            // TODO: get some workable serialization options in here, possibly the same ones we
+            // used when we deserialized this table in the first place?
+            WritableObject.Add(attributeName, value is null
+                ? null
+                : JsonSerializer.SerializeToNode(value, value.GetType()));
         }
 
         /// <inheritdoc />

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonObjectAttributesTable.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonObjectAttributesTable.cs
@@ -14,7 +14,7 @@ namespace NetTopologySuite.Features
     /// Modifications to this table will be observed on <see cref="RootObject"/>, and vice-versa,
     /// including modifications to nested objects and arrays.
     /// </remarks>
-    public sealed class JsonObjectAttributesTable : IAttributesTable
+    public sealed class JsonObjectAttributesTable : IPartiallyDeserializedAttributesTable
     {
         // request to future maintainers: please do not make this public until our System.Text.Json
         // reference is at 8.0.0 or higher. when it is, please throw ArgumentException if the given
@@ -105,31 +105,7 @@ namespace NetTopologySuite.Features
             return RootObject.Select(kvp => Utility.ObjectFromJsonNode(kvp.Value, SerializerOptions)).ToArray();
         }
 
-        /// <summary>
-        /// Attempts to convert this table to a strongly-typed value.
-        /// <para>
-        /// This is essentially just a way of calling
-        /// <see cref="JsonSerializer.Deserialize{TValue}(JsonNode, JsonSerializerOptions)"/>
-        /// on a Feature's <c>"properties"</c> object.
-        /// </para>
-        /// <para>
-        /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
-        /// automatically, for security reasons, so this is the workaround for now.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="T">
-        /// The type of object to convert to.
-        /// </typeparam>
-        /// <param name="options">
-        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization, or
-        /// <see langword="null"/> to use the options from <see cref="SerializerOptions"/>.
-        /// </param>
-        /// <param name="deserialized">
-        /// Receives the converted value on success, or the default value on failure.
-        /// </param>
-        /// <returns>
-        /// A value indicating whether or not the conversion succeeded.
-        /// </returns>
+        /// <inheritdoc />
         public bool TryDeserializeJsonObject<T>(JsonSerializerOptions options, out T deserialized)
         {
             try
@@ -144,34 +120,7 @@ namespace NetTopologySuite.Features
             }
         }
 
-        /// <summary>
-        /// Attempts to get a strongly-typed value for that corresponds to a property of this table.
-        /// <para>
-        /// This is essentially just a way of calling
-        /// <see cref="JsonSerializer.Deserialize{TValue}(JsonNode, JsonSerializerOptions)"/>
-        /// on one of the individual items from a Feature's <c>"properties"</c>.
-        /// </para>
-        /// <para>
-        /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
-        /// automatically, for security reasons, so this is the workaround for now.
-        /// </para>
-        /// </summary>
-        /// <typeparam name="T">
-        /// The type of object to retrieve.
-        /// </typeparam>
-        /// <param name="propertyName">
-        /// The name of the property in this table to get as the specified type.
-        /// </param>
-        /// <param name="options">
-        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization, or
-        /// <see langword="null"/> to use the options from <see cref="SerializerOptions"/>.
-        /// </param>
-        /// <param name="deserialized">
-        /// Receives the converted value on success, or the default value on failure.
-        /// </param>
-        /// <returns>
-        /// A value indicating whether or not the conversion succeeded.
-        /// </returns>
+        /// <inheritdoc />
         public bool TryGetJsonObjectPropertyValue<T>(string propertyName, JsonSerializerOptions options, out T deserialized)
         {
             if (!this.RootObject.TryGetPropertyValue(propertyName, out var elementToTransform))

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonObjectAttributesTable.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonObjectAttributesTable.cs
@@ -1,0 +1,220 @@
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace NetTopologySuite.Features
+{
+    /// <summary>
+    /// An implementation of <see cref="IAttributesTable"/> backed by a <see cref="JsonObject"/>.
+    /// </summary>
+    public sealed class JsonObjectAttributesTable : IAttributesTable
+    {
+        // request to future maintainers: please do not make this public until our System.Text.Json
+        // reference is at 8.0.0 or higher. when it is, please throw ArgumentException if the given
+        // serializerOptions is not read-only (dotnet/runtime#74431). thanks for your consideration.
+        internal JsonObjectAttributesTable(JsonObject rootObject, JsonSerializerOptions serializerOptions)
+        {
+            RootObject = rootObject;
+            SerializerOptions = serializerOptions;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JsonObject"/> object that this instance adapts to fit the
+        /// <see cref="IAttributesTable"/> interface.
+        /// </summary>
+        public JsonObject RootObject { get; }
+
+        /// <summary>
+        /// Gets the <see cref="JsonSerializerOptions"/> object that will be used to save all edits
+        /// made to this table onto <see cref="RootObject"/>.
+        /// </summary>
+        public JsonSerializerOptions SerializerOptions { get; }
+
+        /// <inheritdoc />
+        public object this[string attributeName]
+        {
+            get
+            {
+                return RootObject.TryGetPropertyValue(attributeName, out var prop)
+                    ? ConvertFromJsonNode(prop)
+                    : throw new ArgumentException($"Attribute {attributeName} does not exist!", nameof(attributeName));
+            }
+
+            set
+            {
+                RootObject[attributeName] = ConvertToJsonNode(value);
+            }
+        }
+
+        /// <inheritdoc />
+        public int Count => RootObject.Count;
+
+        /// <inheritdoc />
+        public void Add(string attributeName, object value)
+        {
+            RootObject.Add(attributeName, ConvertToJsonNode(value));
+        }
+
+        /// <inheritdoc />
+        public void DeleteAttribute(string attributeName)
+        {
+            RootObject.Remove(attributeName);
+        }
+
+        /// <inheritdoc />
+        public bool Exists(string attributeName)
+        {
+            return RootObject.ContainsKey(attributeName);
+        }
+
+        /// <inheritdoc />
+        public object GetOptionalValue(string attributeName)
+        {
+            return RootObject.TryGetPropertyValue(attributeName, out var prop)
+                ? ConvertFromJsonNode(prop)
+                : null;
+        }
+
+        /// <inheritdoc />
+        public Type GetType(string attributeName)
+        {
+            if (!RootObject.TryGetPropertyValue(attributeName, out var prop))
+            {
+                throw new ArgumentException($"Attribute {attributeName} does not exist!", nameof(attributeName));
+            }
+
+            return ConvertFromJsonNode(prop)?.GetType() ?? typeof(object);
+        }
+
+        /// <inheritdoc />
+        public string[] GetNames()
+        {
+            return RootObject.Select(kvp => kvp.Key).ToArray();
+        }
+
+        /// <inheritdoc />
+        public object[] GetValues()
+        {
+            return RootObject.Select(kvp => ConvertFromJsonNode(kvp.Value)).ToArray();
+        }
+
+        /// <summary>
+        /// Attempts to convert this table to a strongly-typed value.
+        /// <para>
+        /// This is essentially just a way of calling
+        /// <see cref="JsonSerializer.Deserialize{TValue}(JsonNode, JsonSerializerOptions)"/>
+        /// on a Feature's <c>"properties"</c> object.
+        /// </para>
+        /// <para>
+        /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
+        /// automatically, for security reasons, so this is the workaround for now.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of object to convert to.
+        /// </typeparam>
+        /// <param name="options">
+        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization, or
+        /// <see langword="null"/> to use the options from <see cref="SerializerOptions"/>.
+        /// </param>
+        /// <param name="deserialized">
+        /// Receives the converted value on success, or the default value on failure.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether or not the conversion succeeded.
+        /// </returns>
+        public bool TryDeserializeJsonObject<T>(JsonSerializerOptions options, out T deserialized)
+        {
+            try
+            {
+                deserialized = JsonSerializer.Deserialize<T>(RootObject, options ?? SerializerOptions);
+                return true;
+            }
+            catch (JsonException)
+            {
+                deserialized = default;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to get a strongly-typed value for that corresponds to a property of this table.
+        /// <para>
+        /// This is essentially just a way of calling
+        /// <see cref="JsonSerializer.Deserialize{TValue}(JsonNode, JsonSerializerOptions)"/>
+        /// on one of the individual items from a Feature's <c>"properties"</c>.
+        /// </para>
+        /// <para>
+        /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
+        /// automatically, for security reasons, so this is the workaround for now.
+        /// </para>
+        /// </summary>
+        /// <typeparam name="T">
+        /// The type of object to retrieve.
+        /// </typeparam>
+        /// <param name="propertyName">
+        /// The name of the property in this table to get as the specified type.
+        /// </param>
+        /// <param name="options">
+        /// The <see cref="JsonSerializerOptions"/> to use for the deserialization, or
+        /// <see langword="null"/> to use the options from <see cref="SerializerOptions"/>.
+        /// </param>
+        /// <param name="deserialized">
+        /// Receives the converted value on success, or the default value on failure.
+        /// </param>
+        /// <returns>
+        /// A value indicating whether or not the conversion succeeded.
+        /// </returns>
+        public bool TryGetJsonObjectPropertyValue<T>(string propertyName, JsonSerializerOptions options, out T deserialized)
+        {
+            if (!this.RootObject.TryGetPropertyValue(propertyName, out var elementToTransform))
+            {
+                deserialized = default;
+                return false;
+            }
+
+            try
+            {
+                deserialized = JsonSerializer.Deserialize<T>(elementToTransform, options ?? SerializerOptions);
+                return true;
+            }
+            catch (JsonException)
+            {
+                deserialized = default;
+                return false;
+            }
+        }
+
+        private object ConvertFromJsonNode(JsonNode prop)
+        {
+            switch (prop)
+            {
+                case null:
+                    return null;
+
+                case JsonObject propObj:
+                    return new JsonObjectAttributesTable(propObj, SerializerOptions);
+
+                case JsonArray propArr:
+                    return propArr.Select(ConvertFromJsonNode).ToArray();
+            }
+
+            // else it's a JsonValue... not sure of a cleaner way to handle this than to just reuse
+            // the code we have that deals with JsonElement.
+            JsonElement propAsElement = JsonSerializer.Deserialize<JsonElement>(prop, SerializerOptions);
+            object result = JsonElementAttributesTable.ConvertValue(propAsElement);
+            if (result is JsonElementAttributesTable elementTable)
+            {
+                result = new JsonObjectAttributesTable(JsonObject.Create(elementTable.RootElement.Clone(), RootObject.Options), SerializerOptions);
+            }
+
+            return result;
+        }
+
+        private JsonNode ConvertToJsonNode(object obj)
+        {
+            return JsonSerializer.SerializeToNode(obj, obj?.GetType() ?? typeof(object), SerializerOptions);
+        }
+    }
+}

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonObjectAttributesTable.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/JsonObjectAttributesTable.cs
@@ -123,7 +123,7 @@ namespace NetTopologySuite.Features
         /// <inheritdoc />
         public bool TryGetJsonObjectPropertyValue<T>(string propertyName, JsonSerializerOptions options, out T deserialized)
         {
-            if (!this.RootObject.TryGetPropertyValue(propertyName, out var elementToTransform))
+            if (!RootObject.TryGetPropertyValue(propertyName, out var elementToTransform))
             {
                 deserialized = default;
                 return false;

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjAttributesTableConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjAttributesTableConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 
 using NetTopologySuite.Features;
@@ -13,9 +14,12 @@ namespace NetTopologySuite.IO.Converters
     {
         private readonly string _idPropertyName;
 
-        public StjAttributesTableConverter(string idPropertyName)
+        private readonly bool _allowModifyingAttributesTables;
+
+        public StjAttributesTableConverter(string idPropertyName, bool allowModifyingAttributesTables)
         {
             _idPropertyName = idPropertyName;
+            _allowModifyingAttributesTables = allowModifyingAttributesTables;
         }
 
         /// <summary>
@@ -64,6 +68,9 @@ namespace NetTopologySuite.IO.Converters
                     case JsonValueKind.Null:
                         // this SHOULD only be possible when invoked directly?
                         return null;
+
+                    case JsonValueKind.Object when _allowModifyingAttributesTables:
+                        return new JsonObjectAttributesTable(JsonObject.Create(doc.RootElement.Clone()), options);
 
                     case JsonValueKind.Object:
                         return new JsonElementAttributesTable(doc.RootElement);

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjAttributesTableExtensions.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjAttributesTableExtensions.cs
@@ -46,13 +46,18 @@ namespace NetTopologySuite.IO.Converters
         [Obsolete("Cast to JsonElementAttributesTable and call the instance method instead.")]
         public static bool TryDeserializeJsonObject<T>(this IAttributesTable table, JsonSerializerOptions options, out T deserialized)
         {
-            if (!(table is JsonElementAttributesTable ourAttributesTable))
+            if (table is JsonElementAttributesTable elementAttributesTable)
             {
-                deserialized = default;
-                return false;
+                return elementAttributesTable.TryDeserializeJsonObject(options, out deserialized);
             }
 
-            return ourAttributesTable.TryDeserializeJsonObject(options, out deserialized);
+            if (table is JsonObjectAttributesTable objectAttributesTable)
+            {
+                return objectAttributesTable.TryDeserializeJsonObject(options, out deserialized);
+            }
+
+            deserialized = default;
+            return false;
         }
 
         /// <summary>
@@ -90,16 +95,21 @@ namespace NetTopologySuite.IO.Converters
         /// <returns>
         /// A value indicating whether or not the conversion succeeded.
         /// </returns>
-        [Obsolete("Cast to JsonElementAttributesTable and call the instance method instead.")]
+        [Obsolete("Cast to JsonElementAttributesTable or JsonObjectAttributesTable as appropriate and call the instance method instead.")]
         public static bool TryGetJsonObjectPropertyValue<T>(this IAttributesTable table, string propertyName, JsonSerializerOptions options, out T deserialized)
         {
-            if (!(table is JsonElementAttributesTable ourAttributesTable))
+            if (table is JsonElementAttributesTable elementAttributesTable)
             {
-                deserialized = default;
-                return false;
+                return elementAttributesTable.TryGetJsonObjectPropertyValue(propertyName, options, out deserialized);
             }
 
-            return ourAttributesTable.TryGetJsonObjectPropertyValue(propertyName, options, out deserialized);
+            if (table is JsonObjectAttributesTable objectAttributesTable)
+            {
+                return objectAttributesTable.TryGetJsonObjectPropertyValue(propertyName, options, out deserialized);
+            }
+
+            deserialized = default;
+            return false;
         }
     }
 }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjAttributesTableExtensions.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjAttributesTableExtensions.cs
@@ -7,25 +7,20 @@ namespace NetTopologySuite.IO.Converters
 {
     /// <summary>
     /// Adapter for code that targets older versions of this library that did not expose the
-    /// <see cref="JsonElementAttributesTable"/> class publicly.
+    /// <see cref="IPartiallyDeserializedAttributesTable"/> interface publicly.
     /// </summary>
     public static class StjAttributesTableExtensions
     {
         /// <summary>
-        /// Attempts to convert this table to a strongly-typed value, if the table is an instance of
-        /// the <see cref="JsonElementAttributesTable"/> class.
-        /// <para>
-        /// This is essentially just a way of calling
-        /// <see cref="JsonSerializer.Deserialize{TValue}(ref Utf8JsonReader, JsonSerializerOptions)"/>
-        /// on a Feature's <c>"properties"</c> object.
-        /// </para>
+        /// Attempts to convert this table to a strongly-typed value, if the table implements
+        /// the <see cref="IPartiallyDeserializedAttributesTable"/> interface.
         /// <para>
         /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
         /// automatically, for security reasons, so this is the workaround for now.
         /// </para>
         /// <para>
-        /// This will always return <see langword="false"/> for tables that are not instances of the
-        /// <see cref="JsonElementAttributesTable"/> class.
+        /// This will always return <see langword="false"/> for tables that do not implement the
+        /// <see cref="IPartiallyDeserializedAttributesTable"/> interface.
         /// </para>
         /// </summary>
         /// <typeparam name="T">
@@ -43,38 +38,28 @@ namespace NetTopologySuite.IO.Converters
         /// <returns>
         /// A value indicating whether or not the conversion succeeded.
         /// </returns>
-        [Obsolete("Cast to JsonElementAttributesTable and call the instance method instead.")]
+        [Obsolete("Cast to IPartiallyDeserializedAttributesTable and call the instance method instead.")]
         public static bool TryDeserializeJsonObject<T>(this IAttributesTable table, JsonSerializerOptions options, out T deserialized)
         {
-            if (table is JsonElementAttributesTable elementAttributesTable)
+            if (!(table is IPartiallyDeserializedAttributesTable ourAttributesTable))
             {
-                return elementAttributesTable.TryDeserializeJsonObject(options, out deserialized);
+                deserialized = default;
+                return false;
             }
 
-            if (table is JsonObjectAttributesTable objectAttributesTable)
-            {
-                return objectAttributesTable.TryDeserializeJsonObject(options, out deserialized);
-            }
-
-            deserialized = default;
-            return false;
+            return ourAttributesTable.TryDeserializeJsonObject(options, out deserialized);
         }
 
         /// <summary>
         /// Attempts to get a strongly-typed value for that corresponds to a property of this table,
-        /// if the table is an instance of the <see cref="JsonElementAttributesTable"/> class.
-        /// <para>
-        /// This is essentially just a way of calling
-        /// <see cref="JsonSerializer.Deserialize{TValue}(ref Utf8JsonReader, JsonSerializerOptions)"/>
-        /// on one of the individual items from a Feature's <c>"properties"</c>.
-        /// </para>
+        /// if the table implements the <see cref="IPartiallyDeserializedAttributesTable"/> interface.
         /// <para>
         /// <c>System.Text.Json</c> intentionally omits the functionality that would let us do this
         /// automatically, for security reasons, so this is the workaround for now.
         /// </para>
         /// <para>
-        /// This will always return <see langword="false"/> for tables that are not instances of the
-        /// <see cref="JsonElementAttributesTable"/> class.
+        /// This will always return <see langword="false"/> for tables that do not implement the
+        /// <see cref="IPartiallyDeserializedAttributesTable"/> interface.
         /// </para>
         /// </summary>
         /// <typeparam name="T">
@@ -95,21 +80,16 @@ namespace NetTopologySuite.IO.Converters
         /// <returns>
         /// A value indicating whether or not the conversion succeeded.
         /// </returns>
-        [Obsolete("Cast to JsonElementAttributesTable or JsonObjectAttributesTable as appropriate and call the instance method instead.")]
+        [Obsolete("Cast to IPartiallyDeserializedAttributesTable and call the instance method instead.")]
         public static bool TryGetJsonObjectPropertyValue<T>(this IAttributesTable table, string propertyName, JsonSerializerOptions options, out T deserialized)
         {
-            if (table is JsonElementAttributesTable elementAttributesTable)
+            if (!(table is IPartiallyDeserializedAttributesTable ourAttributesTable))
             {
-                return elementAttributesTable.TryGetJsonObjectPropertyValue(propertyName, options, out deserialized);
+                deserialized = default;
+                return false;
             }
 
-            if (table is JsonObjectAttributesTable objectAttributesTable)
-            {
-                return objectAttributesTable.TryGetJsonObjectPropertyValue(propertyName, options, out deserialized);
-            }
-
-            deserialized = default;
-            return false;
+            return ourAttributesTable.TryGetJsonObjectPropertyValue(propertyName, options, out deserialized);
         }
     }
 }

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/AttributesTableConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/AttributesTableConverterTest.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using NetTopologySuite.Features;
+using NetTopologySuite.IO.Converters;
 using NUnit.Framework;
 
 namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
@@ -14,9 +15,15 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
     ///    This is a test class for AttributesTableConverterTest and is intended
     ///    to contain all AttributesTableConverterTest Unit Tests
     ///</summary>
-    [TestFixture]
+    [TestFixture(false)]
+    [TestFixture(true)]
     public class AttributesTableConverterTest : SandDTest<IAttributesTable>
     {
+        public AttributesTableConverterTest(bool allowModifyingAttributesTables)
+            : base(new GeoJsonConverterFactory(null, false, null, RingOrientationOption.EnforceRfc9746, allowModifyingAttributesTables))
+        {
+        }
+
         ///<summary>
         ///A test for CanConvert
         ///</summary>

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/SandDTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/SandDTest.cs
@@ -70,5 +70,14 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
         {
             return Deserialize(json, options);
         }
+        protected T RoundTrip(T value, JsonSerializerOptions options = null)
+        {
+            using (var ms = new MemoryStream())
+            {
+                JsonSerializer.Serialize(ms, value, options);
+                ms.Position = 0;
+                return JsonSerializer.Deserialize<T>(ms, options);
+            }
+        }
     }
 }

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/SandDTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/SandDTest.cs
@@ -9,8 +9,16 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
 {
     public abstract class SandDTest<T>
     {
+        protected SandDTest() : this(null)
+        {
+        }
+
+        protected SandDTest(GeoJsonConverterFactory geoJsonConverterFactory)
+        {
+            GeoJsonConverterFactory = geoJsonConverterFactory ?? new GeoJsonConverterFactory();
+        }
+
         protected GeoJsonConverterFactory GeoJsonConverterFactory { get; }
-            = new GeoJsonConverterFactory();
 
         protected JsonSerializerOptions DefaultOptions
         {

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/StjAttributesTableExtensionsTests.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/StjAttributesTableExtensionsTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text.Json;
-using System.Text.Json.Nodes;
+
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Converters;
@@ -115,7 +115,7 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
 
         [TestCase(false)]
         [TestCase(true)]
-        public void TryGetJsonObjectPropertyValueShouldActAppropriatelyWhenPropertyIsPresent(bool afterModification)
+        public void TryGetJsonObjectPropertyValueShouldActAppropriatelyWhenPropertyIsPresent(bool allowModification)
         {
             const string Json = @"{
     ""type"": ""Feature"",
@@ -157,7 +157,7 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
 }";
             var options = new JsonSerializerOptions
             {
-                Converters = { new GeoJsonConverterFactory(null, false, null, RingOrientationOption.DoNotModify, afterModification) },
+                Converters = { new GeoJsonConverterFactory(null, false, null, RingOrientationOption.EnforceRfc9746, allowModification) },
                 PropertyNameCaseInsensitive = true,
             };
 
@@ -166,62 +166,6 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
             Assert.That(feature.Geometry, Is.InstanceOf<Point>());
             Assert.That(feature.Geometry.Coordinate, Is.EqualTo(new Coordinate(-74.0445, 40.6892)));
             Assert.That(feature.Attributes, Is.Not.Null);
-
-            if (afterModification)
-            {
-                Assert.That(feature.Attributes, Is.InstanceOf<JsonObjectAttributesTable>());
-                JsonObjectAttributesTable attributes = (JsonObjectAttributesTable)feature.Attributes;
-                JsonObject rootObject = attributes.RootObject; // modifications should write through
-
-                feature.Attributes.Add("hello", "world!");
-                Assert.That(feature.Attributes.Exists("hello"));
-                Assert.That(feature.Attributes["hello"], Is.EqualTo("world!"));
-                Assert.That(rootObject.TryGetPropertyValue("hello", out JsonNode helloValue));
-                Assert.That(helloValue.GetValue<string>(), Is.EqualTo("world!"));
-
-                GasStation gasStation = new GasStation
-                {
-                    Id = Guid.NewGuid(),
-                    Name = "Somebody",
-                    Location = GeometryFactory.Default.CreatePoint(new Coordinate(1, 3)),
-                    Owner = new Person
-                    {
-                        Id = Guid.NewGuid(),
-                        Name = "Jason",
-                        Age = 72,
-                    },
-                };
-
-                feature.Attributes["hello"] = gasStation;
-
-                Assert.That(feature.Attributes["hello"], Is.InstanceOf<JsonObjectAttributesTable>());
-                JsonObjectAttributesTable helloAttribute = (JsonObjectAttributesTable)feature.Attributes["hello"];
-
-                Assert.That(helloAttribute["Location"], Is.InstanceOf<JsonObjectAttributesTable>());
-                JsonObjectAttributesTable helloLocationAttribute = (JsonObjectAttributesTable)helloAttribute["Location"];
-
-                Assert.That(helloLocationAttribute.TryDeserializeJsonObject(null, out Point helloLocationPt));
-                Assert.That(helloLocationPt.Coordinate, Is.EqualTo(new Coordinate(1, 3)));
-
-                helloLocationAttribute["coordinates"] = new JsonArray(JsonValue.Create(6.0), JsonValue.Create(8.0));
-                Assert.That(((JsonObjectAttributesTable)helloAttribute["Location"]).TryDeserializeJsonObject(null, out helloLocationPt));
-                Assert.That(helloLocationPt.Coordinate, Is.EqualTo(new Coordinate(6, 8)));
-
-                // overwriting the coordinates at the deepest attributes table that we create in our
-                // tree should write through ALL the way to the topmost root object.
-                Assert.That(((JsonValue)(((JsonArray)((JsonObject)((JsonObject)rootObject["hello"])["Location"])["coordinates"])[0])).GetValue<double>(), Is.EqualTo(6.0));
-                Assert.That(((JsonValue)(((JsonArray)((JsonObject)((JsonObject)rootObject["hello"])["Location"])["coordinates"])[1])).GetValue<double>(), Is.EqualTo(8.0));
-
-                feature.Attributes.DeleteAttribute("hello");
-                Assert.That(!feature.Attributes.Exists("hello"));
-                Assert.That(!rootObject.ContainsKey("hello"));
-            }
-            else
-            {
-                // as of 3.x, we now expose the table so that the caller can get the JsonElement for
-                // their own inspection and manipulation.
-                Assert.That(feature.Attributes, Is.InstanceOf<JsonElementAttributesTable>());
-            }
 
             Assert.Multiple(() =>
             {
@@ -346,6 +290,17 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
                 Assert.That(!feature.Attributes.TryGetJsonObjectPropertyValue("null", options, out DateTime _), () => "DateTime from null");
                 Assert.That(!feature.Attributes.TryGetJsonObjectPropertyValue("null", options, out DateTimeOffset _), () => "DateTimeOffset from null");
                 Assert.That(!feature.Attributes.TryGetJsonObjectPropertyValue("null", options, out Guid _), () => "Guid from null");
+
+                // as of 3.x, we now expose the table so that the caller can get the underlying STJ
+                // DOM object for their own inspection and manipulation.
+                if (allowModification)
+                {
+                    Assert.That(feature.Attributes, Is.InstanceOf<JsonObjectAttributesTable>());
+                }
+                else
+                {
+                    Assert.That(feature.Attributes, Is.InstanceOf<JsonElementAttributesTable>());
+                }
             });
 
             // complex type, with two properties: one of a user-defined complex type, and one that

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/StjAttributesTableExtensionsTests.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/StjAttributesTableExtensionsTests.cs
@@ -293,14 +293,7 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
 
                 // as of 3.x, we now expose the table so that the caller can get the underlying STJ
                 // DOM object for their own inspection and manipulation.
-                if (allowModification)
-                {
-                    Assert.That(feature.Attributes, Is.InstanceOf<JsonObjectAttributesTable>());
-                }
-                else
-                {
-                    Assert.That(feature.Attributes, Is.InstanceOf<JsonElementAttributesTable>());
-                }
+                Assert.That(feature.Attributes, Is.InstanceOf<IPartiallyDeserializedAttributesTable>());
             });
 
             // complex type, with two properties: one of a user-defined complex type, and one that

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/WritableAttributesTableConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/WritableAttributesTableConverterTest.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text.Json.Nodes;
 
 using NetTopologySuite.Features;
@@ -72,12 +73,15 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
             Assert.That(nearestGasStationLocationAttribute.TryDeserializeJsonObject(null, out Point nearestGasStationLocationPt));
             Assert.That(nearestGasStationLocationPt.Coordinate, Is.EqualTo(new Coordinate(1, 3)));
 
-            nearestGasStationLocationAttribute["coordinates"] = new JsonArray(JsonValue.Create(6.0), JsonValue.Create(8.0));
+            Assert.That(nearestGasStationLocationAttribute["coordinates"], Is.InstanceOf<IList<object>>());
+            IList<object> nearestGasStationLocationCoordinatesArray = (IList<object>)nearestGasStationLocationAttribute["coordinates"];
+            nearestGasStationLocationCoordinatesArray[0] = 6.0;
+            nearestGasStationLocationCoordinatesArray[1] = 8.0;
             Assert.That(((JsonObjectAttributesTable)nearestGasStationAttribute["Location"]).TryDeserializeJsonObject(null, out nearestGasStationLocationPt));
             Assert.That(nearestGasStationLocationPt.Coordinate, Is.EqualTo(new Coordinate(6, 8)));
 
-            // overwriting the coordinates at the deepest attributes table that we create in our
-            // tree should write through ALL the way to the topmost root object.
+            // overwriting the coordinates at the deepest nested container that we create should
+            // write through ALL the way to the topmost root object.
             Assert.That(((JsonValue)(((JsonArray)((JsonObject)((JsonObject)rootObject["nearestGasStation"])["Location"])["coordinates"])[0])).GetValue<double>(), Is.EqualTo(6.0));
             Assert.That(((JsonValue)(((JsonArray)((JsonObject)((JsonObject)rootObject["nearestGasStation"])["Location"])["coordinates"])[1])).GetValue<double>(), Is.EqualTo(8.0));
 

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/WritableAttributesTableConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/WritableAttributesTableConverterTest.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
+using NUnit.Framework;
+
+namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
+{
+    [TestFixture]
+    public sealed class WritableAttributesTableConverterTest : SandDTest<IFeature>
+    {
+        public WritableAttributesTableConverterTest()
+            : base(new GeoJsonConverterFactory(null, false, null, RingOrientationOption.EnforceRfc9746, true))
+        {
+        }
+
+        [Test]
+        public void ModificationsShouldBeVisibleNearlyEverywhere()
+        {
+            IFeature feature = FromJsonString(@"{
+    ""type"": ""Feature"",
+    ""geometry"": {
+        ""type"": ""Point"",
+        ""coordinates"": [-74.0445, 40.6892]
+    },
+    ""properties"": {
+        ""hello"": ""world!""
+    }
+}", DefaultOptions);
+
+            Assert.That(feature.Geometry, Is.InstanceOf<Point>());
+            Assert.That(feature.Geometry.Coordinate, Is.EqualTo(new Coordinate(-74.0445, 40.6892)));
+
+            Assert.That(feature.Attributes, Is.InstanceOf<JsonObjectAttributesTable>());
+            JsonObjectAttributesTable attributes = (JsonObjectAttributesTable)feature.Attributes;
+            JsonObject rootObject = attributes.RootObject; // modifications should write through
+
+            Assert.That(feature.Attributes.Exists("hello"));
+            Assert.That(feature.Attributes["hello"], Is.EqualTo("world!"));
+            Assert.That(rootObject.TryGetPropertyValue("hello", out JsonNode helloValue));
+            Assert.That(helloValue.GetValue<string>(), Is.EqualTo("world!"));
+
+            feature.Attributes.DeleteAttribute("hello");
+            Assert.That(!feature.Attributes.Exists("hello"));
+            Assert.That(!rootObject.ContainsKey("hello"));
+
+            // initialize "nearestGasStation" to just a string at first...
+            feature.Attributes.Add("nearestGasStation", "there are none");
+            Assert.That(feature.Attributes.Exists("nearestGasStation"));
+            Assert.That(feature.Attributes["nearestGasStation"], Is.EqualTo("there are none"));
+            Assert.That(rootObject.TryGetPropertyValue("nearestGasStation", out JsonNode nearestGasStationValue));
+            Assert.That(nearestGasStationValue.GetValue<string>(), Is.EqualTo("there are none"));
+
+            // but override it right away with a juicy object instead of a string.
+            feature.Attributes["nearestGasStation"] = new GasStation
+            {
+                Id = Guid.NewGuid(),
+                Name = "Somebody",
+                Location = GeometryFactory.Default.CreatePoint(new Coordinate(1, 3)),
+            };
+
+            Assert.That(feature.Attributes["nearestGasStation"], Is.InstanceOf<JsonObjectAttributesTable>());
+            JsonObjectAttributesTable nearestGasStationAttribute = (JsonObjectAttributesTable)feature.Attributes["nearestGasStation"];
+
+            Assert.That(nearestGasStationAttribute["Location"], Is.InstanceOf<JsonObjectAttributesTable>());
+            JsonObjectAttributesTable nearestGasStationLocationAttribute = (JsonObjectAttributesTable)nearestGasStationAttribute["Location"];
+
+            Assert.That(nearestGasStationLocationAttribute.TryDeserializeJsonObject(null, out Point nearestGasStationLocationPt));
+            Assert.That(nearestGasStationLocationPt.Coordinate, Is.EqualTo(new Coordinate(1, 3)));
+
+            nearestGasStationLocationAttribute["coordinates"] = new JsonArray(JsonValue.Create(6.0), JsonValue.Create(8.0));
+            Assert.That(((JsonObjectAttributesTable)nearestGasStationAttribute["Location"]).TryDeserializeJsonObject(null, out nearestGasStationLocationPt));
+            Assert.That(nearestGasStationLocationPt.Coordinate, Is.EqualTo(new Coordinate(6, 8)));
+
+            // overwriting the coordinates at the deepest attributes table that we create in our
+            // tree should write through ALL the way to the topmost root object.
+            Assert.That(((JsonValue)(((JsonArray)((JsonObject)((JsonObject)rootObject["nearestGasStation"])["Location"])["coordinates"])[0])).GetValue<double>(), Is.EqualTo(6.0));
+            Assert.That(((JsonValue)(((JsonArray)((JsonObject)((JsonObject)rootObject["nearestGasStation"])["Location"])["coordinates"])[1])).GetValue<double>(), Is.EqualTo(8.0));
+        }
+
+        private sealed class GasStation
+        {
+            public Guid Id { get; set; }
+
+            public string Name { get; set; }
+
+            public Point Location { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Resolves #117

`JsonElementAttributesTable` is just fine as it is, so it hasn't been touched.  Instead, I've created a new table type that's backed by the (relatively) new (to us) `JsonObject`, from the `System.Text.Json.Nodes` namespace.

This design is optimized for people who want to take an `IFeature` that comes from 4STJ and make relatively few changes to its `Attributes` before handing it off somewhere else.

I would have personally preferred if `IFeature` / `IAttributesTable` had been read-only, as it seems unlikely that someone actually **needs** to be able to modify the objects created by our I/O helpers.  However, there is at least one consumer who has come to rely on being able to do this in the Newtonsoft.Json version, and so it seems reasonable to provide a more straightforward upgrade path.

Especially since, unlike `System.Collections.Generic.ICollection<T>`, we don't document that instances might sometimes be read-only, nor do we give anything like `IsReadOnly` that someone can check to discover whether or not a particular instance can be modified.
- *`System.Collections.Generic.ICollection<T>` is almost as bad, to be fair: it does have this documentation and `IsReadOnly` that you can check, but based on my experience, I would wager that a typical developer is likely to just **assume** that every instance of `ICollection<T>` is writable (if they even know about `IsReadOnly` at all!) and write code that's problematic in exactly the same way... but at least there, I could argue that it's their fault for not reading the warning labels...*