### PR TITLE
Fix feature serialization when attributes or geometry are null (#128)

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON/Converters/FeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON/Converters/FeatureConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.Serialization;
 
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
@@ -63,18 +62,12 @@ namespace NetTopologySuite.IO.Converters
             }
 
             // geometry
-            if (serializer.NullValueHandling == NullValueHandling.Include || !(feature.Geometry is null))
-            {
-                writer.WritePropertyName("geometry");
-                serializer.Serialize(writer, feature.Geometry, typeof(Geometry));
-            }
+            writer.WritePropertyName("geometry");
+            serializer.Serialize(writer, feature.Geometry, typeof(Geometry));
 
             // properties
-            if (serializer.NullValueHandling == NullValueHandling.Include || !(feature.Attributes is null))
-            {
-                writer.WritePropertyName("properties");
-                serializer.Serialize(writer, feature.Attributes, typeof(IAttributesTable));
-            }
+            writer.WritePropertyName("properties");
+            serializer.Serialize(writer, feature.Attributes, typeof(IAttributesTable));
 
             writer.WriteEndObject();
         }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjFeatureConverter.cs
@@ -51,18 +51,12 @@ namespace NetTopologySuite.IO.Converters
                 StjGeometryConverter.WriteBBox(writer, value.BoundingBox, options);
 
             // geometry
-            if (value.Geometry != null || options.ShouldWriteNullValues())
-            {
-                writer.WritePropertyName("geometry");
-                JsonSerializer.Serialize(writer, value.Geometry, options);
-            }
+            writer.WritePropertyName("geometry");
+            JsonSerializer.Serialize(writer, value.Geometry, options);
 
             // properties
-            if (value.Attributes != null || options.ShouldWriteNullValues())
-            {
-                writer.WritePropertyName("properties");
-                JsonSerializer.Serialize(writer, value.Attributes, options);
-            }
+            writer.WritePropertyName("properties");
+            JsonSerializer.Serialize(writer, value.Attributes, options);
 
             writer.WriteEndObject();
         }

--- a/test/NetTopologySuite.IO.GeoJSON.Test/FeatureConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON.Test/FeatureConverterTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Text;
 using NetTopologySuite.Features;
 using NetTopologySuite.Geometries;
@@ -51,6 +50,25 @@ namespace NetTopologySuite.IO.GeoJSON.Test
             Assert.AreEqual("{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[23.0,56.0]},\"properties\":{\"test1\":\"value1\"}}", sb.ToString());
         }
 
+        /// <summary>
+        /// Tests whether required feature members are written, even if they are null.
+        /// </summary>
+        [Test]
+        public void WriteJsonShouldIgnoreCustomNullWritingOptionsTest()
+        {
+            var target = new FeatureConverter();
+            var sb = new StringBuilder();
+            var writer = new JsonTextWriter(new StringWriter(sb));
+
+            IFeature value = new Feature(null, null);
+            var serializer = GeoJsonSerializer.Create(
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore },
+                GeometryFactory.Default);
+            target.WriteJson(writer, value, serializer);
+            writer.Flush();
+
+            Assert.AreEqual("{\"type\":\"Feature\",\"geometry\":null,\"properties\":null}", sb.ToString());
+        }
 
         ///<summary>
         ///    A test for WriteJson

--- a/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssue81.cs
+++ b/test/NetTopologySuite.IO.GeoJSON.Test/Issues/NetTopologySuite.IO.GeoJSON/GitHubIssue81.cs
@@ -41,13 +41,15 @@ namespace NetTopologySuite.IO.GeoJSON.Test.Issues.NetTopologySuite.IO.GeoJSON
       ""type"": ""Feature"",
       ""geometry"": {
         ""type"": ""MultiPolygon"",""coordinates"":[[[[0.0,0.0],[0.0,1.0],[1.0,1.0],[1.0,0.0],[0.0,0.0]]]]
-      }
+      },
+      ""properties"": null
     },
     {
       ""type"": ""Feature"",
       ""geometry"": {
         ""type"": ""MultiPolygon"",""coordinates"":[[[[2.0,2.0],[2.0,4.0],[4.0,4.0],[4.0,2.0],[2.0,2.0]]]]
-      }
+      },
+      ""properties"": null
     }
   ]
 }";

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/FeatureConverterTest.cs
@@ -68,6 +68,20 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
             //Assert.AreEqual("{\"type\":\"Feature\",\"geometry\":{\"type\":\"Point\",\"coordinates\":[23.1,56.2]},\"properties\":{\"test1\":\"value1\"}}", ToJson(value));
         }
 
+        /// <summary>
+        /// Tests whether required feature members are written, even if they are null.
+        /// </summary>
+        [Test]
+        public void WriteJsonShouldIgnoreCustomNullWritingOptionsTest()
+        {
+            IFeature value = new Feature(null, null);
+            var options = DefaultOptions;
+            options.WriteIndented = false;
+            options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+
+            string json = ToJsonString(value, options);
+            Assert.AreEqual("{\"type\":\"Feature\",\"geometry\":null,\"properties\":null}", json);
+        }
 
         ///<summary>
         ///    A test for WriteJson


### PR DESCRIPTION
Make feature serialization compliant with RFC 7946, as described in #128.