### PR TITLE
Use `PrecisionModel` for serializing/deserializing coordinates (STJ)

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -202,7 +202,7 @@ namespace NetTopologySuite.IO.Converters
             if (GeometryTypes.Contains(typeToConvert))
                 return new StjGeometryConverter(_factory, _writeGeometryBBox, _ringOrientationOption);
             if (typeToConvert == typeof(Envelope))
-                return new StjEnvelopeConverter();
+                return new StjEnvelopeConverter(_factory.PrecisionModel);
             if (typeToConvert == typeof(FeatureCollection))
                 return new StjFeatureCollectionConverter(_writeGeometryBBox);
             if (typeof(IFeature).IsAssignableFrom(typeToConvert))

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/GeoJsonConverterFactory.cs
@@ -190,6 +190,7 @@ namespace NetTopologySuite.IO.Converters
         public override bool CanConvert(Type typeToConvert)
         {
             return GeometryTypes.Contains(typeToConvert)
+                   || typeToConvert == typeof(Envelope)
                    || typeof(IFeature).IsAssignableFrom(typeToConvert)
                    || typeToConvert == typeof(FeatureCollection)
                    || typeof(IAttributesTable).IsAssignableFrom(typeToConvert);
@@ -200,6 +201,8 @@ namespace NetTopologySuite.IO.Converters
         {
             if (GeometryTypes.Contains(typeToConvert))
                 return new StjGeometryConverter(_factory, _writeGeometryBBox, _ringOrientationOption);
+            if (typeToConvert == typeof(Envelope))
+                return new StjEnvelopeConverter();
             if (typeToConvert == typeof(FeatureCollection))
                 return new StjFeatureCollectionConverter(_writeGeometryBBox);
             if (typeof(IFeature).IsAssignableFrom(typeToConvert))

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjEnvelopeConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjEnvelopeConverter.cs
@@ -1,7 +1,5 @@
 ﻿using NetTopologySuite.Geometries;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -9,6 +7,13 @@ namespace NetTopologySuite.IO.Converters
 {
     internal class StjEnvelopeConverter : JsonConverter<Envelope>
     {
+        private readonly PrecisionModel _precisionModel;
+
+        public StjEnvelopeConverter(PrecisionModel precisionModel)
+        {
+            _precisionModel = precisionModel;
+        }
+
         public override Envelope Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
             Envelope res = null;
@@ -22,19 +27,19 @@ namespace NetTopologySuite.IO.Converters
             {
                 reader.ReadToken(JsonTokenType.StartArray);
 
-                double minX = reader.GetDouble();
+                double minX = reader.GetDouble(_precisionModel);
                 reader.Read();
-                double minY = reader.GetDouble();
+                double minY = reader.GetDouble(_precisionModel);
                 reader.Read();
-                double maxX = reader.GetDouble();
+                double maxX = reader.GetDouble(_precisionModel);
                 reader.Read();
-                double maxY = reader.GetDouble();
+                double maxY = reader.GetDouble(_precisionModel);
                 reader.Read();
 
                 if (reader.TokenType == JsonTokenType.Number)
                 {
                     maxX = maxY;
-                    maxY = reader.GetDouble();
+                    maxY = reader.GetDouble(_precisionModel);
                     reader.Read();
                     reader.Read();
                 }
@@ -59,10 +64,10 @@ namespace NetTopologySuite.IO.Converters
             }
 
             writer.WriteStartArray();
-            writer.WriteNumberValue(value.MinX);
-            writer.WriteNumberValue(value.MinY);
-            writer.WriteNumberValue(value.MaxX);
-            writer.WriteNumberValue(value.MaxY);
+            writer.WriteNumberValue(value.MinX, _precisionModel);
+            writer.WriteNumberValue(value.MinY, _precisionModel);
+            writer.WriteNumberValue(value.MaxX, _precisionModel);
+            writer.WriteNumberValue(value.MaxY, _precisionModel);
             writer.WriteEndArray();
         }
     }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjEnvelopeConverter.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjEnvelopeConverter.cs
@@ -1,0 +1,69 @@
+﻿using NetTopologySuite.Geometries;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NetTopologySuite.IO.Converters
+{
+    internal class StjEnvelopeConverter : JsonConverter<Envelope>
+    {
+        public override Envelope Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            Envelope res = null;
+
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                // #57: callers expect us to have read past the last token
+                reader.Read();
+            }
+            else
+            {
+                reader.ReadToken(JsonTokenType.StartArray);
+
+                double minX = reader.GetDouble();
+                reader.Read();
+                double minY = reader.GetDouble();
+                reader.Read();
+                double maxX = reader.GetDouble();
+                reader.Read();
+                double maxY = reader.GetDouble();
+                reader.Read();
+
+                if (reader.TokenType == JsonTokenType.Number)
+                {
+                    maxX = maxY;
+                    maxY = reader.GetDouble();
+                    reader.Read();
+                    reader.Read();
+                }
+
+                reader.ReadToken(JsonTokenType.EndArray);
+
+                res = new Envelope(minX, maxX, minY, maxY);
+            }
+
+            //reader.Read(); // move away from array end
+            return res;
+        }
+
+        public override void Write(Utf8JsonWriter writer, Envelope value, JsonSerializerOptions options)
+        {
+            // if we don't want to write "null" bounding boxes, bail out.
+            if (value?.IsNull != false)
+            {
+                writer.WriteNullValue();
+
+                return;
+            }
+
+            writer.WriteStartArray();
+            writer.WriteNumberValue(value.MinX);
+            writer.WriteNumberValue(value.MinY);
+            writer.WriteNumberValue(value.MaxX);
+            writer.WriteNumberValue(value.MaxY);
+            writer.WriteEndArray();
+        }
+    }
+}

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Coordinates.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Coordinates.cs
@@ -8,7 +8,6 @@ namespace NetTopologySuite.IO.Converters
     {
         private void WriteCoordinateSequence(Utf8JsonWriter writer, CoordinateSequence sequence, JsonSerializerOptions options, bool multiple = true, OrientationIndex orientation = OrientationIndex.None)
         {
-            //writer.WritePropertyName("coordinates");
             if (sequence == null)
             {
                 writer.WriteNullValue();
@@ -29,15 +28,17 @@ namespace NetTopologySuite.IO.Converters
             for (int i = 0; i < sequence.Count; i++)
             {
                 writer.WriteStartArray();
-                writer.WriteNumberValue(sequence.GetX(i));
-                writer.WriteNumberValue(sequence.GetY(i));
+
+                writer.WriteNumberValue(sequence.GetX(i), _geometryFactory.PrecisionModel);
+                writer.WriteNumberValue(sequence.GetY(i), _geometryFactory.PrecisionModel);
 
                 if (hasZ)
                 {
                     double z = sequence.GetZ(i);
                     if (!double.IsNaN(z))
-                        writer.WriteNumberValue(sequence.GetZ(i));
+                        writer.WriteNumberValue(z, _geometryFactory.PrecisionModel);
                 }
+
                 writer.WriteEndArray();
 
                 if (!multiple) break;

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjGeometryConverter.Envelope.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Text.Json;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json;
 using NetTopologySuite.Geometries;
 
 namespace NetTopologySuite.IO.Converters
@@ -10,7 +8,6 @@ namespace NetTopologySuite.IO.Converters
         internal static Envelope ReadBBox(ref Utf8JsonReader reader, JsonSerializerOptions options)
         {
             Envelope res = null;
-
             if (reader.TokenType == JsonTokenType.Null)
             {
                 // #57: callers expect us to have read past the last token
@@ -18,28 +15,7 @@ namespace NetTopologySuite.IO.Converters
             }
             else
             {
-                reader.ReadToken(JsonTokenType.StartArray);
-
-                double minX = reader.GetDouble();
-                reader.Read();
-                double minY = reader.GetDouble();
-                reader.Read();
-                double maxX = reader.GetDouble();
-                reader.Read();
-                double maxY = reader.GetDouble();
-                reader.Read();
-
-                if (reader.TokenType == JsonTokenType.Number)
-                {
-                    maxX = maxY;
-                    maxY = reader.GetDouble();
-                    reader.Read();
-                    reader.Read();
-                }
-
-                reader.ReadToken(JsonTokenType.EndArray);
-
-                res = new Envelope(minX, maxX, minY, maxY);
+                res = JsonSerializer.Deserialize<Envelope>(ref reader, options);
             }
 
             //reader.Read(); // move away from array end
@@ -66,13 +42,7 @@ namespace NetTopologySuite.IO.Converters
             }
 
             writer.WritePropertyName("bbox");
-
-            writer.WriteStartArray();
-            writer.WriteNumberValue(value.MinX);
-            writer.WriteNumberValue(value.MinY);
-            writer.WriteNumberValue(value.MaxX);
-            writer.WriteNumberValue(value.MaxY);
-            writer.WriteEndArray();
+            JsonSerializer.Serialize(writer, value, typeof(Envelope), options);
         }
     }
 }

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/Utility.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/Utility.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using NetTopologySuite.Features;
+using NetTopologySuite.Geometries;
 using NetTopologySuite.IO.Properties;
 
 namespace NetTopologySuite.IO.Converters
@@ -103,5 +104,23 @@ namespace NetTopologySuite.IO.Converters
                 ? reader.ValueSequence.ToArray()
                 : reader.ValueSpan.ToArray());
         }
+
+        /// <summary>
+        /// Parses the current JSON token value from the source as a <see cref="double"/>. Rounds a value to the <see cref="PrecisionModel"/> grid.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        /// <param name="precisionModel">The precision model to round to.</param>
+        /// <returns>The rounded value</returns>
+        internal static double GetDouble(this Utf8JsonReader reader, PrecisionModel precisionModel)
+            => precisionModel.MakePrecise(reader.GetDouble());
+
+        /// <summary>
+        /// Rounds a <see cref="double"/> value to the <see cref="PrecisionModel"/> grid. Writes the rounded value (as a JSON number) as an element of a JSON array.
+        /// </summary>
+        /// <param name="writer">The writer.</param>
+        /// <param name="value">The value to write.</param>
+        /// <param name="precisionModel">The precision model to round to.</param>
+        internal static void WriteNumberValue(this Utf8JsonWriter writer, double value, PrecisionModel precisionModel)
+            => writer.WriteNumberValue(precisionModel.MakePrecise(value));
     }
 }

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue135.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Issues/Issue135.cs
@@ -1,0 +1,37 @@
+﻿using NetTopologySuite.Geometries;
+using NetTopologySuite.IO.Converters;
+using NetTopologySuite.IO.GeoJSON4STJ.Test.Converters;
+using NUnit.Framework;
+using System.Text.Json;
+
+namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Issues
+{
+    internal class Issue135 : SandDTest<Geometry>
+    {
+        [Test, GeoJsonIssueNumber(135)]
+        public void TestOutputPrecision()
+        {
+            var coords = new[]
+            {
+                new Coordinate(0.001, 0.001),
+                new Coordinate(10.1, 0.002),
+                new Coordinate(10, 10.1),
+                new Coordinate(0.05, 9.999),
+                new Coordinate(0.001, 0.001)
+            };
+            var factory = new GeometryFactory(new PrecisionModel(10), 4326);
+            var polygon = factory.CreatePolygon(coords);
+
+            string json = JsonSerializer.Serialize(polygon, new JsonSerializerOptions
+            {
+                ReadCommentHandling = JsonCommentHandling.Skip,
+                Converters =
+                {
+                    new GeoJsonConverterFactory(factory)
+                }
+            });
+
+            Assert.That(json, Is.EqualTo("{\"type\":\"Polygon\",\"coordinates\":[[[0,0],[10.1,0],[10,10.1],[0.1,10],[0,0]]]}"));
+        }
+    }
+}


### PR DESCRIPTION
- Serialization and deserialization of the `Envelope` type moved to it's own converter, so that it easily can use a `PrecisionModel` parameter.
- Extension methods for `Utf8JsonWriter` and `Utf8JsonReader` that uses a `PrecisionModel` parameter.
- Serialization and deserialization of coordinates uses the extension methods with the current `PrecisionModel`.
- Fixes #135 

I am not sure if `PrecisionModel` should be used for the `Z` coordinate. This is something I want, but this is not supported by the Newtonsoft GeoJSON serializer.