### PR TITLE
Deserialize MultiPolygon Array of Empty Coordinates Array

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjParsedCoordinates.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjParsedCoordinates.cs
@@ -51,6 +51,15 @@ namespace NetTopologySuite.IO.Converters
             reader.AssertToken(JsonTokenType.StartArray);
             reader.ReadOrThrow();
 
+            if (reader.TokenType == JsonTokenType.EndArray)
+            {
+                reader.ReadOrThrow();
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    return default;
+                }
+            }
+
             if (reader.TokenType == JsonTokenType.Number)
             {
                 return new StjParsedCoordinates(ParseCoordinateSequence(ref reader, factory));

--- a/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjParsedCoordinates.cs
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/Converters/StjParsedCoordinates.cs
@@ -56,7 +56,7 @@ namespace NetTopologySuite.IO.Converters
                 reader.ReadOrThrow();
                 if (reader.TokenType == JsonTokenType.EndArray)
                 {
-                    return default;
+                    return new StjParsedCoordinates(factory.CreateMultiPolygon(new Polygon[] { factory.CreatePolygon() }));
                 }
             }
 

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/GeometryConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/GeometryConverterTest.cs
@@ -23,6 +23,18 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
             Assert.That(geom.IsEmpty);
         }
 
+
+        [TestCase("MultiPolygon")]
+        public void TestReadWithArrayOfEmptyCoordinatesArray(string type)
+        {
+            string geoJson = @$"{{ ""type"" : ""{type}"", ""coordinates"": [ [] ] }}";
+            var options = DefaultOptions;
+            var geom = Deserialize(geoJson, options);
+
+            Assert.That(geom != null);
+            Assert.That(geom.IsEmpty);
+        }
+
         [GeoJsonIssueNumber(57)]
         [TestCase("{\"type\": \"Point\", \"coordinates\": [], \"bbox\": null}")]
         [TestCase("{\"type\": \"LineString\", \"coordinates\": [], \"bbox\": null}")]

--- a/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/GeometryConverterTest.cs
+++ b/test/NetTopologySuite.IO.GeoJSON4STJ.Test/Converters/GeometryConverterTest.cs
@@ -23,15 +23,15 @@ namespace NetTopologySuite.IO.GeoJSON4STJ.Test.Converters
             Assert.That(geom.IsEmpty);
         }
 
-
-        [TestCase("MultiPolygon")]
-        public void TestReadWithArrayOfEmptyCoordinatesArray(string type)
+        [TestCase]
+        public void TestMultiPolygonReadWithArrayOfEmptyCoordinatesArray()
         {
-            string geoJson = @$"{{ ""type"" : ""{type}"", ""coordinates"": [ [] ] }}";
+            string geoJson = @"{ ""type"" : ""MultiPolygon"", ""coordinates"": [ [] ] }";
             var options = DefaultOptions;
             var geom = Deserialize(geoJson, options);
 
             Assert.That(geom != null);
+            Assert.That(new MultiPolygon(new Polygon[] { new Polygon(null) }) == geom);
             Assert.That(geom.IsEmpty);
         }
 


### PR DESCRIPTION
gdal-bin ogr2ogr outputs multipolygons with empty geometries in this format:
```
{ "type" : "MultiPolygon", "coordinates": [ [ ] ] }
```
NetTopologySuite throws an exception when encountering this data:
```
System.InvalidOperationException : Cannot get the value of a token type 'EndArray' as a string.
```
If the first two tokens are start array, then the next token may be an end array. If that token is end array, then the next token after it must also be an end array. Those tokens should result in a multi polygon with an empty polygon.