### PR TITLE
Bump System.Text.Json to v8.0.5 resolving CVE-2024-43485

### DIFF
--- a/src/NetTopologySuite.IO.GeoJSON4STJ/NetTopologySuite.IO.GeoJSON4STJ.csproj
+++ b/src/NetTopologySuite.IO.GeoJSON4STJ/NetTopologySuite.IO.GeoJSON4STJ.csproj
@@ -34,7 +34,7 @@
   <ItemGroup>
     <PackageReference Include="NetTopologySuite" Version="[2.0.0, 3.0.0-A)" />
     <PackageReference Include="NetTopologySuite.Features" Version="[2.1.0, 3.0.0-A)" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes vulnerability [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4) by bumping `System.Text.Json` to `v8.0.5`. Note that the [latest released version](https://github.com/NetTopologySuite/NetTopologySuite.IO.GeoJSON/releases/tag/v4.0.0) is running `System.Text.Json` `v6.0.3`, which is also impacted by [CVE-2024-43485](https://github.com/advisories/GHSA-8g4q-xg66-9fp4).

Partially addresses #151, the remaining work being to create a new release.

Thanks!

